### PR TITLE
Add an integration test for resources in jar files

### DIFF
--- a/src/test/java/com/google/testing/compile/JarFileResourcesCompilationTest.java
+++ b/src/test/java/com/google/testing/compile/JarFileResourcesCompilationTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2013 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.testing.compile;
+
+import static com.google.testing.compile.JavaSourceSubjectFactory.javaSource;
+import static org.truth0.Truth.ASSERT;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.net.URL;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import com.google.common.io.Resources;
+
+/**
+ * An integration test to ensure that testing works when resources are in jar files.
+ *
+ * @author Gregory Kick
+ * @author Christian Gruber
+ */
+@RunWith(JUnit4.class)
+public class JarFileResourcesCompilationTest {
+  @Rule
+  public TemporaryFolder folder = new TemporaryFolder();
+  private File jarFile;
+
+  @Before
+  public void createJarFile() throws IOException {
+    this.jarFile = folder.newFile("test.jar");
+    JarOutputStream out = new JarOutputStream(new FileOutputStream(jarFile));
+    JarEntry helloWorldEntry = new JarEntry("test/HelloWorld.java");
+    out.putNextEntry(helloWorldEntry);
+    out.write(Resources.toByteArray(Resources.getResource("HelloWorld.java")));
+    out.close();
+  }
+
+  @Test
+  public void compilesResourcesInJarFiles() throws IOException {
+    ASSERT.about(javaSource())
+      .that(JavaFileObjects.forResource(
+          new URL("jar:" + jarFile.toURI() + "!/test/HelloWorld.java")))
+      .hasNoErrors();
+  }
+}

--- a/src/test/java/com/google/testing/compile/JavaFileObjectsTest.java
+++ b/src/test/java/com/google/testing/compile/JavaFileObjectsTest.java
@@ -25,6 +25,8 @@ import java.net.URISyntaxException;
 import javax.tools.JavaFileObject;
 
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
 import com.google.common.io.Resources;
 
@@ -33,6 +35,7 @@ import com.google.common.io.Resources;
  *
  *  @author Gregory Kick
  */
+@RunWith(JUnit4.class)
 public class JavaFileObjectsTest {
   @Test public void forResource_inJarFile() throws URISyntaxException, IOException {
     JavaFileObject resourceInJar = JavaFileObjects.forResource("java/lang/Object.class");

--- a/src/test/java/com/google/testing/compile/JavaSourcesSubjectFactoryTest.java
+++ b/src/test/java/com/google/testing/compile/JavaSourcesSubjectFactoryTest.java
@@ -19,15 +19,6 @@ import static com.google.testing.compile.JavaSourceSubjectFactory.javaSource;
 import static org.junit.Assert.fail;
 import static org.truth0.Truth.ASSERT;
 
-import com.google.common.collect.ImmutableSet;
-import com.google.common.io.Resources;
-
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
-import org.truth0.FailureStrategy;
-import org.truth0.TestVerb;
-
 import java.io.IOException;
 import java.io.Writer;
 import java.util.Arrays;
@@ -39,6 +30,15 @@ import javax.annotation.processing.RoundEnvironment;
 import javax.lang.model.SourceVersion;
 import javax.lang.model.element.TypeElement;
 import javax.tools.JavaFileObject;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.truth0.FailureStrategy;
+import org.truth0.TestVerb;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.io.Resources;
 
 /**
  * Tests {@link JavaSourcesSubjectFactory} (and {@link JavaSourceSubjectFactory}).


### PR DESCRIPTION
This manually creates a jar file just because I wanted to avoid the particular mavenisms in the test.  I also skipped the negative test because it was basically a test for Guava code rather than a test of the compile-tester.
