### PR TITLE
Prove support of JavaFileObjects.forResource() for sources in a jar file.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,13 @@
       <version>1.3.9</version>
       <optional>true</optional>
     </dependency>
+    <dependency>
+      <groupId>javax.inject</groupId>
+      <artifactId>javax.inject</artifactId>
+      <version>1</version>
+      <classifier>sources</classifier>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/src/test/java/com/google/testing/compile/JavaFileObjectsTest.java
+++ b/src/test/java/com/google/testing/compile/JavaFileObjectsTest.java
@@ -18,15 +18,15 @@ package com.google.testing.compile;
 import static javax.tools.JavaFileObject.Kind.CLASS;
 import static org.truth0.Truth.ASSERT;
 
+import com.google.common.io.Resources;
+
+import org.junit.Test;
+
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 
 import javax.tools.JavaFileObject;
-
-import org.junit.Test;
-
-import com.google.common.io.Resources;
 
 /**
  *  Tests {@link JavaFileObjects}.
@@ -41,5 +41,15 @@ public class JavaFileObjectsTest {
     ASSERT.that(resourceInJar.getName())
         .isEqualTo(Resources.getResource("java/lang/Object.class").toString());
     ASSERT.that(resourceInJar.isNameCompatible("Object", CLASS));
+  }
+
+  @Test
+  public void cannotFindResource() {
+    try {
+      JavaFileObjects.forResource("javax/inject/Inject.javaX");
+      ASSERT.fail("Should fail with an IllegalArgumentException.");
+    } catch (IllegalArgumentException e) {
+      ASSERT.that(e.getMessage()).contains("resource javax/inject/Inject.javaX not found");
+    }
   }
 }

--- a/src/test/java/com/google/testing/compile/JavaSourcesSubjectFactoryTest.java
+++ b/src/test/java/com/google/testing/compile/JavaSourcesSubjectFactoryTest.java
@@ -18,6 +18,7 @@ package com.google.testing.compile;
 import static com.google.testing.compile.JavaSourceSubjectFactory.javaSource;
 import static org.junit.Assert.fail;
 import static org.truth0.Truth.ASSERT;
+import static org.truth0.Truth.ASSUME;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.io.Resources;
@@ -137,6 +138,12 @@ public class JavaSourcesSubjectFactoryTest {
     ASSERT.that(noopProcessor2.invoked).isTrue();
   }
 
+  public void compilesResourcesInJarFiles() {
+    ASSUME.that(getClass().getResource("javax/inject/Inject.java").getProtocol()).is("jar");
+    ASSERT.about(javaSource())
+        .that(JavaFileObjects.forResource("javax/inject/Inject.java"))
+        .hasNoErrors();
+  }
 
   private static final class GeneratingProcessor extends AbstractProcessor {
     static final String GENERATED_CLASS_NAME = "Blah";


### PR DESCRIPTION
Add an integration test to show that JavaFileObjects.forResource() will properly work with sources obtained from jar files.
