### PR TITLE
Test against all available JVMs on travis-ci.org.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,11 @@ language: java
 install: mvn install clean --fail-never --quiet -DskipTests=true -Dinvoker.skip=true
 script: mvn verify
 
+jdk:
+  - openjdk6
+  - openjdk7
+  - oraclejdk7
+
 notifications:
   email: false
 


### PR DESCRIPTION
Not sure if we want to do this against all of them, and certainly we should wait until we decide that we are fixing java6 before submitting this as-is, but this at least enables travis to build against all of the JVMs it has handy. 
