### PR TITLE
Update the compilation logic to make sure that processors that throw exceptions still cause exception to be thrown in older versions of javac. 

### DIFF
--- a/src/main/java/com/google/testing/compile/CompilationFailureException.java
+++ b/src/main/java/com/google/testing/compile/CompilationFailureException.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2013 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.testing.compile;
+
+/**
+ * An exception thrown to indicate that compilation has failed for an unknown reason.
+ */
+@SuppressWarnings("serial")
+public class CompilationFailureException extends RuntimeException {
+  CompilationFailureException() {
+    super("Compilation failed, but did not report any error diagnostics or throw any exceptions. "
+        + "This behavior has been observed in older versions of javac, which swallow exceptions "
+        + "and log them on System.err. Check there for more information.");
+  }
+}

--- a/src/test/java/com/google/testing/compile/JavaSourcesSubjectFactoryTest.java
+++ b/src/test/java/com/google/testing/compile/JavaSourcesSubjectFactoryTest.java
@@ -40,7 +40,6 @@ import org.junit.runners.JUnit4;
 import org.truth0.FailureStrategy;
 import org.truth0.TestVerb;
 
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.io.Resources;
 
@@ -82,7 +81,7 @@ public class JavaSourcesSubjectFactoryTest {
   }
 
   @Test
-  public void compilesWithoutError_exceptionPassedThrough() {
+  public void compilesWithoutError_exceptionCreatedOrPassedThrough() {
     final RuntimeException e = new RuntimeException();
     try {
       VERIFY.about(javaSource())
@@ -101,8 +100,11 @@ public class JavaSourcesSubjectFactoryTest {
           })
           .compilesWithoutError();
       fail();
+    } catch (CompilationFailureException expected) {
+      // some old javacs don't pass through exceptions, so we create one
     } catch (RuntimeException expected) {
-      ASSERT.that(Throwables.getRootCause(expected)).is(e);
+      // newer jdks throw a runtime exception whose cause is the original exception
+      ASSERT.that(expected.getCause()).is(e);
     }
   }
 


### PR DESCRIPTION
Fixes #13.
