### PR TITLE
Make maven faster on ubuntu

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,10 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>2.5</version>
+      </plugin>
+      <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.1</version>
         <configuration>


### PR DESCRIPTION
maven-jar-plugin < 2.5 is insanely slow on ubunto because: reasons. 