### PR TITLE
Add an ability to pass in compiler configuration options

### DIFF
--- a/src/main/java/com/google/testing/compile/Compilation.java
+++ b/src/main/java/com/google/testing/compile/Compilation.java
@@ -32,6 +32,7 @@ import com.sun.tools.javac.api.JavacTool;
 import java.io.IOException;
 import java.util.List;
 import java.util.Locale;
+import java.util.Set;
 
 import javax.annotation.processing.Processor;
 import javax.tools.Diagnostic;
@@ -55,7 +56,7 @@ final class Compilation {
    * @throws RuntimeException if compilation fails.
    */
   static Result compile(Iterable<? extends Processor> processors,
-      Iterable<? extends JavaFileObject> sources) {
+      Set<String> options, Iterable<? extends JavaFileObject> sources) {
     JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
     if (compiler == null) {
       throw new IllegalStateException("Java Compiler is not present. "
@@ -69,7 +70,7 @@ final class Compilation {
         null, // explicitly use the default because old versions of javac log some output on stderr
         fileManager,
         diagnosticCollector,
-        ImmutableSet.<String>of(),
+        ImmutableSet.copyOf(options),
         ImmutableSet.<String>of(),
         sources);
     task.setProcessors(processors);

--- a/src/main/java/com/google/testing/compile/CompilationRule.java
+++ b/src/main/java/com/google/testing/compile/CompilationRule.java
@@ -88,6 +88,7 @@ public final class CompilationRule implements TestRule {
             return false;
           }
         }),
+        ImmutableSet.<String>of(),
         // just compile _something_
         ImmutableList.of(JavaFileObjects.forSourceLines("Dummy", "final class Dummy {}")));
         checkState(result.successful(), result);

--- a/src/main/java/com/google/testing/compile/ProcessedCompileTesterFactory.java
+++ b/src/main/java/com/google/testing/compile/ProcessedCompileTesterFactory.java
@@ -25,6 +25,13 @@ import javax.annotation.processing.Processor;
  * @author Gregory Kick
  */
 public interface ProcessedCompileTesterFactory {
+
+  /** Adds options that will be passed to the compiler. */
+  @CheckReturnValue ProcessedCompileTesterFactory withCompilerOptions(Iterable<String> options);
+  
+  /** Adds options that will be passed to the compiler. */
+  @CheckReturnValue ProcessedCompileTesterFactory withCompilerOptions(String... options);
+  
   /** Adds {@linkplain Processor annotation processors} to the compilation being tested.  */
   @CheckReturnValue
   CompileTester processedWith(Processor first, Processor... rest);

--- a/src/test/java/com/google/testing/compile/JavaSourcesSubjectFactoryTest.java
+++ b/src/test/java/com/google/testing/compile/JavaSourcesSubjectFactoryTest.java
@@ -15,6 +15,7 @@
  */
 package com.google.testing.compile;
 
+import static com.google.common.truth.Truth.assertAbout;
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assert_;
 import static com.google.testing.compile.JavaSourceSubjectFactory.javaSource;
@@ -27,6 +28,7 @@ import com.google.common.io.ByteSource;
 import com.google.common.io.Resources;
 import com.google.common.truth.FailureStrategy;
 import com.google.common.truth.TestVerb;
+import com.google.common.truth.Truth;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -35,6 +37,7 @@ import org.junit.runners.JUnit4;
 import java.io.IOException;
 import java.io.Writer;
 import java.util.Arrays;
+import java.util.Map;
 import java.util.Set;
 
 import javax.annotation.processing.AbstractProcessor;
@@ -517,7 +520,14 @@ public class JavaSourcesSubjectFactoryTest {
 
   private static final class NoOpProcessor extends AbstractProcessor {
     boolean invoked = false;
+    Map<String, String> options;
 
+    @Override
+    public synchronized void init(ProcessingEnvironment processingEnv) {
+      super.init(processingEnv);
+      options = processingEnv.getOptions();
+    }
+    
     @Override
     public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
       invoked = true;


### PR DESCRIPTION
Add an ability to pass in compiler configuration options (say, to configure annotation processors' flags).

-------------
Created by MOE: http://code.google.com/p/moe-java
MOE_MIGRATED_REVID=85151739