### PR TITLE
Support alternate JavaCompilers (such as ECJ) in JavaSourcesSubject

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,14 @@
       <version>1.3.9</version>
       <optional>true</optional>
     </dependency>
+
+    <!--Eclipse compiler for test-->
+    <dependency>
+      <groupId>org.eclipse.jdt.core.compiler</groupId>
+      <artifactId>ecj</artifactId>
+      <version>4.4.2</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/src/main/java/com/google/testing/compile/Compilation.java
+++ b/src/main/java/com/google/testing/compile/Compilation.java
@@ -55,9 +55,8 @@ final class Compilation {
    *
    * @throws RuntimeException if compilation fails.
    */
-  static Result compile(Iterable<? extends Processor> processors,
+  static Result compile(JavaCompiler compiler, Iterable<? extends Processor> processors,
       Set<String> options, Iterable<? extends JavaFileObject> sources) {
-    JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
     if (compiler == null) {
       throw new IllegalStateException("Java Compiler is not present. "
           + "May be, you need to include tools.jar on your dependency list.");
@@ -71,7 +70,7 @@ final class Compilation {
         fileManager,
         diagnosticCollector,
         ImmutableSet.copyOf(options),
-        ImmutableSet.<String>of(),
+        null, // explicitly use the default behaviour because Eclipse compiler fails with empty Set
         sources);
     task.setProcessors(processors);
     boolean successful = task.call();
@@ -83,8 +82,7 @@ final class Compilation {
    * Parse {@code sources} into {@linkplain CompilationUnitTree compilation units}.  This method
    * <b>does not</b> compile the sources.
    */
-  static ParseResult parse(Iterable<? extends JavaFileObject> sources) {
-    JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+  static ParseResult parse(JavaCompiler compiler, Iterable<? extends JavaFileObject> sources) {
     DiagnosticCollector<JavaFileObject> diagnosticCollector =
         new DiagnosticCollector<JavaFileObject>();
     InMemoryJavaFileManager fileManager = new InMemoryJavaFileManager(
@@ -94,7 +92,7 @@ final class Compilation {
         fileManager,
         diagnosticCollector,
         ImmutableSet.<String>of(),
-        ImmutableSet.<String>of(),
+        null, // explicitly use the default behaviour because Eclipse compiler fails with empty Set
         sources);
     try {
       Iterable<? extends CompilationUnitTree> parsedCompilationUnits = task.parse();

--- a/src/main/java/com/google/testing/compile/CompilationRule.java
+++ b/src/main/java/com/google/testing/compile/CompilationRule.java
@@ -37,6 +37,7 @@ import javax.lang.model.SourceVersion;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.util.Elements;
 import javax.lang.model.util.Types;
+import javax.tools.ToolProvider;
 
 /**
  * A {@link JUnit4} {@link Rule} that executes tests such that a instances of {@link Elements} and
@@ -56,7 +57,8 @@ public final class CompilationRule implements TestRule {
     return new Statement() {
       @Override public void evaluate() throws Throwable {
         final AtomicReference<Throwable> thrown = new AtomicReference<Throwable>();
-        Result result = Compilation.compile(ImmutableList.of(new AbstractProcessor() {
+        Result result = Compilation.compile(ToolProvider.getSystemJavaCompiler(),
+          ImmutableList.of(new AbstractProcessor() {
           @Override
           public SourceVersion getSupportedSourceVersion() {
             return SourceVersion.latest();

--- a/src/main/java/com/google/testing/compile/MoreTrees.java
+++ b/src/main/java/com/google/testing/compile/MoreTrees.java
@@ -38,6 +38,7 @@ import com.sun.source.util.TreePathScanner;
 import java.util.Arrays;
 
 import javax.annotation.Nullable;
+import javax.tools.ToolProvider;
 
 /**
  * A class containing methods which are useful for gaining access to {@code Tree} instances from
@@ -52,8 +53,8 @@ final class MoreTrees {
 
   /** Parses the source given into a {@link CompilationUnitTree}. */
   static CompilationUnitTree parseLinesToTree(Iterable<String> source) {
-    Iterable<? extends CompilationUnitTree> parseResults = Compilation.parse(ImmutableList.of(
-        JavaFileObjects.forSourceLines("", source))).compilationUnits();
+    Iterable<? extends CompilationUnitTree> parseResults = Compilation.parse(ToolProvider.getSystemJavaCompiler(),
+      ImmutableList.of(JavaFileObjects.forSourceLines("", source))).compilationUnits();
     return Iterables.getOnlyElement(parseResults);
   }
 
@@ -64,7 +65,8 @@ final class MoreTrees {
 
   /** Parses the source given and produces a {@link Compilation.ParseResult}. */
   static Compilation.ParseResult parseLines(Iterable<String> source) {
-    return Compilation.parse(ImmutableList.of(JavaFileObjects.forSourceLines("", source)));
+    return Compilation.parse(ToolProvider.getSystemJavaCompiler(),
+      ImmutableList.of(JavaFileObjects.forSourceLines("", source)));
   }
 
   /**

--- a/src/main/java/com/google/testing/compile/ProcessedCompileTesterFactory.java
+++ b/src/main/java/com/google/testing/compile/ProcessedCompileTesterFactory.java
@@ -17,6 +17,7 @@ package com.google.testing.compile;
 
 import javax.annotation.CheckReturnValue;
 import javax.annotation.processing.Processor;
+import javax.tools.JavaCompiler;
 
 /**
  * Creates {@link CompileTester} instances that test compilation with provided {@link Processor}
@@ -24,7 +25,11 @@ import javax.annotation.processing.Processor;
  *
  * @author Gregory Kick
  */
-public interface ProcessedCompileTesterFactory {
+public interface ProcessedCompileTesterFactory extends CompileTester{
+
+  /** Specify compiler (Javac, Eclipse ECJ, ...) **/
+  @CheckReturnValue
+  ProcessedCompileTesterFactory withCompiler(JavaCompiler var1);
 
   /** Adds options that will be passed to the compiler. */
   @CheckReturnValue ProcessedCompileTesterFactory withCompilerOptions(Iterable<String> options);

--- a/src/test/java/com/google/testing/compile/JavaSourcesSubjectFactoryTest.java
+++ b/src/test/java/com/google/testing/compile/JavaSourcesSubjectFactoryTest.java
@@ -29,6 +29,7 @@ import com.google.common.io.Resources;
 import com.google.common.truth.FailureStrategy;
 import com.google.common.truth.TestVerb;
 
+import org.eclipse.jdt.internal.compiler.tool.EclipseCompiler;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -82,6 +83,15 @@ public class JavaSourcesSubjectFactoryTest {
   }
 
   @Test
+  public void compilesWithoutErrorWithEclipseCompiler() {
+    assertAbout(javaSource())
+        .that(JavaFileObjects.forResource(Resources.getResource("HelloWorld.java")))
+        .withCompiler(new EclipseCompiler())
+        .withCompilerOptions("-nowarn", "-1.6")
+        .compilesWithoutError();
+  }
+
+  @Test
   public void compilesWithoutError_failureReportsFiles() {
     try {
       VERIFY.about(javaSource())
@@ -116,16 +126,16 @@ public class JavaSourcesSubjectFactoryTest {
       VERIFY.about(javaSource())
           .that(JavaFileObjects.forResource("HelloWorld.java"))
           .processedWith(new AbstractProcessor() {
-            @Override
-            public Set<String> getSupportedAnnotationTypes() {
-              return ImmutableSet.of("*");
-            }
+              @Override
+              public Set<String> getSupportedAnnotationTypes() {
+                  return ImmutableSet.of("*");
+              }
 
-            @Override
-            public boolean process(Set<? extends TypeElement> annotations,
-                RoundEnvironment roundEnv) {
-              throw e;
-            }
+              @Override
+              public boolean process(Set<? extends TypeElement> annotations,
+                                     RoundEnvironment roundEnv) {
+                  throw e;
+              }
           })
           .compilesWithoutError();
       fail();


### PR DESCRIPTION
New syntax to inject custom compiler:

```java
    assertAbout(javaSource())
        .that(JavaFileObjects.forResource(Resources.getResource("HelloWorld.java")))
        .withCompiler(new EclipseCompiler())
        .withCompilerOptions("-nowarn", "-1.6")
        .compilesWithoutError();
```