### PR TITLE
return not same file when comparing InMemoryJavaFileObject with RegularFileObject

### DIFF
--- a/src/main/java/com/google/testing/compile/InMemoryJavaFileManager.java
+++ b/src/main/java/com/google/testing/compile/InMemoryJavaFileManager.java
@@ -80,6 +80,8 @@ final class InMemoryJavaFileManager extends ForwardingJavaFileManager<JavaFileMa
     if (a instanceof InMemoryJavaFileObject) {
       if (b instanceof InMemoryJavaFileObject) {
         return ((InMemoryJavaFileObject) a).toUri().equals(((InMemoryJavaFileObject) b).toUri());
+      } else {
+        return false;
       }
     }
     if (b instanceof InMemoryJavaFileObject) {


### PR DESCRIPTION
`InMemoryJavaFileManager.isSameFile` does not cover case when `a` is `InMemoryJavaFileObject` and `b` is not. This leads to call to `super.isSameFile` which throws `IllegalArgumentException` becouse has no knowledge of `InMemoryJavaFileObject`