### PR TITLE
Added support to find files in the java default package

### DIFF
--- a/src/main/java/com/google/testing/compile/JavaSourcesSubject.java
+++ b/src/main/java/com/google/testing/compile/JavaSourcesSubject.java
@@ -517,8 +517,11 @@ public final class JavaSourcesSubject
       // packageName is a valid package name.
       // We're relying on the implementation of location.getName() to be equivalent to the path of
       // the location.
-      String expectedFilename = new StringBuilder(location.getName()).append('/')
-          .append(packageName.replace('.', '/')).append('/').append(relativeName).toString();
+      StringBuilder fileNameBuilder = new StringBuilder(location.getName()).append('/');
+      if(packageName != null && !packageName.isEmpty()) {
+        fileNameBuilder.append(packageName.replace('.', '/')).append('/');
+      }
+      String expectedFilename = fileNameBuilder.append(relativeName).toString();
 
       for (JavaFileObject generated : result.generatedFilesByKind().values()) {
         if (generated.toUri().getPath().endsWith(expectedFilename)) {

--- a/src/test/java/com/google/testing/compile/JavaSourcesSubjectFactoryTest.java
+++ b/src/test/java/com/google/testing/compile/JavaSourcesSubjectFactoryTest.java
@@ -20,6 +20,7 @@ import static com.google.common.truth.Truth.assertAbout;
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.testing.compile.JavaSourceSubjectFactory.javaSource;
 import static javax.tools.StandardLocation.CLASS_OUTPUT;
+import static javax.tools.StandardLocation.SOURCE_OUTPUT;
 import static org.junit.Assert.fail;
 
 import com.google.common.collect.ImmutableList;
@@ -386,6 +387,19 @@ public class JavaSourcesSubjectFactoryTest {
     }
   }
 
+  
+  @Test
+  public void generatesClassNamed() {
+    assertAbout(javaSource())
+        .that(JavaFileObjects.forResource("HelloWorld.java"))
+        .processedWith(new GeneratingProcessor())
+        .compilesWithoutError()
+        .and()
+        .generatesFileNamed(SOURCE_OUTPUT, "", "Blah.java")
+        .and()
+        .generatesFileNamed(CLASS_OUTPUT, "", "Blah.class");
+  }
+  
   @Test
   public void generatesFileNamed() {
     assertAbout(javaSource())


### PR DESCRIPTION
Previously the path would consist of "OUTPUT//File.java" leading to no results and failing any tests including generated sources in the default package.