### PR TITLE
Added support for operating directly on the generated source/class files of the compilation

### DIFF
--- a/src/main/java/com/google/testing/compile/CompileTester.java
+++ b/src/main/java/com/google/testing/compile/CompileTester.java
@@ -18,6 +18,7 @@ package com.google.testing.compile;
 import com.google.common.io.ByteSource;
 
 import java.nio.charset.Charset;
+import java.util.Map;
 
 import javax.tools.Diagnostic;
 import javax.tools.JavaFileManager;
@@ -128,12 +129,57 @@ public interface CompileTester {
     ChainingClause<T> atColumn(long columnNumber);
   }
 
+  public interface BiConsumer<T, U> {
+    void accept(T t, U u);
+  }
+
+  public interface Consumer<T> {
+    void accept(T t);
+  }
+
+  public interface CompilationResultConsumer extends BiConsumer<String, JavaFileObject> {}
+
+  public interface CompilationResultsConsumer extends Consumer<Map<String, JavaFileObject>> {}
+
+  /**
+   * The clause in the fluent API that allows to operate on the generated source or class files
+   * by supplying a consumer function. The consumer function will be invoked with the generated
+   * file names and {@linkplain JavaFileObject} objects.
+   *
+   * @param T the non-generic clause type implementing this interface
+   */
+  public interface GenerationClause<T> {
+
+    T forEachOfWhich(CompilationResultConsumer consumer);
+
+    T forAllOfWhich(CompilationResultsConsumer consumer);
+  }
+
+  /**
+   * The clause in the fluent API that allows to operate directly on the generated source files
+   * and compiled class files.
+   *
+   * @param T the non-generic clause type implementing this interface
+   */
+  public interface CompilationWithResultsClause<T> {
+
+    /**
+     * Returns a container that allows operating on generated source files
+     */
+    GenerationClause<T> generatesSources();
+
+    /**
+     * Returns a container that allows operating on generated class files
+     */
+    GenerationClause<T> generatesClasses();
+  }
+
   /**
    * The clause in the fluent API that checks that files were generated.
    *
    * @param T the non-generic clause type implementing this interface
    */
-  public interface GeneratedPredicateClause<T> {
+  public interface GeneratedPredicateClause<T> extends CompilationWithResultsClause<T> {
     /**
      * Checks that a source file with an equivalent
      * <a href="http://en.wikipedia.org/wiki/Abstract_syntax_tree">AST</a> was generated for each of

--- a/src/main/java/com/google/testing/compile/JavaSourcesSubject.java
+++ b/src/main/java/com/google/testing/compile/JavaSourcesSubject.java
@@ -41,6 +41,7 @@ import java.io.IOException;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -585,6 +586,59 @@ public final class JavaSourcesSubject
 
     protected GeneratedCompilationBuilder(Result result) {
       super(result);
+    }
+
+    @Override
+    public GenerationClause<T> generatesSources() {
+      return withCompilationResultsOfKind(JavaFileObject.Kind.SOURCE);
+    }
+
+    @Override
+    public GenerationClause<T> generatesClasses() {
+      return withCompilationResultsOfKind(JavaFileObject.Kind.CLASS);
+    }
+
+    protected GenerationClause<T> withCompilationResultsOfKind(final JavaFileObject.Kind kind) {
+      return new GenerationClause<T>() {
+        private static final String SOURCE_OUTPUT = "/SOURCE_OUTPUT/";
+        private static final String CLASS_OUTPUT = "/CLASS_OUTPUT/";
+        @Override
+        public T forEachOfWhich(CompilationResultConsumer consumer) {
+          if (consumer != null) {
+            for (JavaFileObject generatedJavaFileObject : result.generatedFilesByKind().get(kind)) {
+              consumer.accept(cleanPath(generatedJavaFileObject.getName()), generatedJavaFileObject);
+            }
+          }
+          return thisObject();
+        }
+
+        @Override
+        public T forAllOfWhich(CompilationResultsConsumer consumer) {
+          if (consumer != null) {
+            Map<String, JavaFileObject> generatedJavaFileObjects = new HashMap<String, JavaFileObject>();
+            for (JavaFileObject generatedJavaFileObject : result.generatedFilesByKind().get(kind)) {
+              generatedJavaFileObjects.put(cleanPath(generatedJavaFileObject.getName()), generatedJavaFileObject);
+            }
+            consumer.accept(generatedJavaFileObjects);
+          }
+          return thisObject();
+        }
+
+        private final String cleanPath(String filePath) {
+          if (filePath == null) {
+            return filePath;
+          }
+          else if (filePath.startsWith(SOURCE_OUTPUT)) {
+            return filePath.substring(SOURCE_OUTPUT.length());
+          }
+          else if (filePath.startsWith(CLASS_OUTPUT)) {
+            return filePath.substring(CLASS_OUTPUT.length());
+          }
+          else {
+            return filePath;
+          }
+        }
+      };
     }
 
     @Override

--- a/src/test/java/com/google/testing/compile/JavaFileObjectsTest.java
+++ b/src/test/java/com/google/testing/compile/JavaFileObjectsTest.java
@@ -21,7 +21,6 @@ import static org.junit.Assert.fail;
 
 import com.google.common.io.Resources;
 
-
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;

--- a/src/test/java/com/google/testing/compile/JavaSourcesSubjectFactoryTest.java
+++ b/src/test/java/com/google/testing/compile/JavaSourcesSubjectFactoryTest.java
@@ -36,6 +36,7 @@ import org.junit.runners.JUnit4;
 import java.io.IOException;
 import java.io.Writer;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
@@ -845,6 +846,65 @@ public class JavaSourcesSubjectFactoryTest {
       assertThat(expected.getMessage()).contains(GeneratingProcessor.GENERATED_CLASS_NAME);
       assertThat(expected.getMessage()).contains(failingExpectationName);
     }
+  }
+
+  @Test
+  public void generatesSources_forEachOfWhich() {
+    final Map<String, JavaFileObject> results = new HashMap<String, JavaFileObject>();
+    VERIFY.about(javaSource())
+        .that(JavaFileObjects.forResource("HelloWorld.java"))
+        .processedWith(new GeneratingProcessor())
+        .compilesWithoutError()
+        .and().generatesSources().forEachOfWhich(new CompileTester.CompilationResultConsumer() {
+      public void accept(String name, JavaFileObject javaFileObject) {
+        results.put(name, javaFileObject);
+      }
+    });
+    assertThat(results.keySet()).containsExactly("Blah.java");
+  }
+
+  @Test
+  public void generatesSources_forAllOfWhich() {
+    VERIFY.about(javaSource())
+        .that(JavaFileObjects.forResource("HelloWorld.java"))
+        .processedWith(new GeneratingProcessor())
+        .compilesWithoutError()
+        .and().generatesSources().forAllOfWhich(new CompileTester.CompilationResultsConsumer() {
+      @Override
+      public void accept(Map<String, JavaFileObject> javaFileObjectMap) {
+        assertThat(javaFileObjectMap.keySet()).containsExactly("Blah.java");
+      }
+    });
+  }
+
+  @Test
+  public void generatesClasses_forEachOfWhich() {
+    final Map<String, JavaFileObject> results = new HashMap<String, JavaFileObject>();
+    VERIFY.about(javaSource())
+        .that(JavaFileObjects.forResource("HelloWorld.java"))
+        .processedWith(new GeneratingProcessor())
+        .compilesWithoutError()
+        .and().generatesClasses().forEachOfWhich(new CompileTester.CompilationResultConsumer() {
+      @Override
+      public void accept(String name, JavaFileObject javaFileObject) {
+        results.put(name, javaFileObject);
+      }
+    });
+    assertThat(results.keySet()).containsAllOf("Blah.class", "test/HelloWorld.class");
+  }
+
+  @Test
+  public void generatesClasses_forAllOfWhich() {
+    VERIFY.about(javaSource())
+        .that(JavaFileObjects.forResource("HelloWorld.java"))
+        .processedWith(new GeneratingProcessor())
+        .compilesWithoutError()
+        .and().generatesClasses().forAllOfWhich(new CompileTester.CompilationResultsConsumer() {
+      @Override
+      public void accept(Map<String, JavaFileObject> javaFileObjectMap) {
+        assertThat(javaFileObjectMap.keySet()).containsAllOf("Blah.class", "test/HelloWorld.class");
+      }
+    });
   }
 
   @Test


### PR DESCRIPTION
This pull request is a continuation of the discussion at [https://github.com/google/compile-testing/issues/70](https://github.com/google/compile-testing/issues/70).

While I agree with the notion that having the ability to execute generated class files may be out of scope for compile-testing, I felt that at least allowing direct access to the list of generated `JavaFileObject(s)` in addition to the currently available comparison methods, should still be worth consideration. In this case, the user can decide whether he wants do some additional checking/operations (which are not provided by compile-testing itself) on the resulting source/class files of the compilation without having to recompile the same classes a second time.

To implement this, I added two methods - `GeneratedPredicateClause.generatesSources()` and `GeneratedPredicateClause.generatesClasses()` - that allow access to the generated source and class files via the `forEachOfWhich(BiConsumer<String, JavaFileObject>)` and `forAllOfWhich(Consumer<Map<JavaFileObject>>)` methods.
