### PR TITLE
Make diagnostic failure messages more useful

### DIFF
--- a/src/main/java/com/google/testing/compile/CompilationSubject.java
+++ b/src/main/java/com/google/testing/compile/CompilationSubject.java
@@ -177,7 +177,7 @@ public final class CompilationSubject extends Subject<CompilationSubject, Compil
     StringBuilder listing =
         new StringBuilder(String.format(headingFormat, formatArgs)).append('\n');
     for (Diagnostic<?> diagnostic : diagnostics) {
-      listing.append(diagnostic.getMessage(null)).append('\n');
+      listing.append(diagnostic).append('\n');
     }
     return listing.toString();
   }


### PR DESCRIPTION
Before, you'd fail with a message such as:
  missing type arguments for generic class java.util.Map<K,V>

Now, you'd fail with a message such as:
IMyTestAidl.java:39: warning: [rawtypes] found raw type: java.util.Map
  Map sendMapReceiveMap(Map map) throws RemoteException;
                        ^
  missing type arguments for generic class java.util.Map<K,V>

This makes it much easier to debug test failure messages and figure out where the unexpected warning is coming from.