### PR TITLE
Fix path issue on Windows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: java
+
 install: mvn -B -U install clean --fail-never --quiet -DskipTests=true -Dinvoker.skip=true
 script: mvn -B verify
 
@@ -12,3 +13,7 @@ branches:
   only:
     - master
     - /^release.*$/
+
+cache:
+  directories:
+  - $HOME/.m2

--- a/src/main/java/com/google/testing/compile/Compiler.java
+++ b/src/main/java/com/google/testing/compile/Compiler.java
@@ -25,6 +25,7 @@ import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.testing.compile.Compilation.Status;
+import java.io.File;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.ArrayList;
@@ -194,7 +195,7 @@ public abstract class Compiler {
       }
     }
 
-    return Joiner.on(':').join(classpaths);
+    return Joiner.on(File.pathSeparatorChar).join(classpaths);
   }
 
   private Compiler copy(ImmutableList<Processor> processors, ImmutableList<String> options) {


### PR DESCRIPTION
This fixes a bug in classpath discerning on Windows (`;` vs `:`). 

Also, my person fork's travis builds are failing because of not being on Java 1.8.0_131, I saw the builds being done for the main repository have the correct java version, so I'm unsure how to fix this. 