### PR TITLE
Add support for Appveyor testing

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,22 @@
+
+install:
+  # See for Java locations: https://www.appveyor.com/docs/build-environment/#java
+  - SET JAVA_HOME=C:\Program Files\Java\jdk1.8.0
+  - SET PATH=%JAVA_HOME%\bin;%PATH%
+  - javac -version
+
+  - mvn -B -U install clean --fail-never --quiet -DskipTests=true -Dinvoker.skip=true
+
+build_script:
+  - mvn -B compile
+
+test_script:
+  - mvn -B verify
+
+branches:
+  only:
+    - master
+    - /^release.*$/
+
+cache:
+  - C:\Users\appveyor\.m2


### PR DESCRIPTION
Appveyor needs to be [enabled](https://www.appveyor.com), but it is free for open source projects. This commit has a working configuration. 

Sample: https://ci.appveyor.com/project/Nava2/compile-testing/build/1.0.4
* This was a branch used in PR #122 originally, but it's configured not to build against non-master/release branches. 