### PR TITLE
Provide ClassLoader for loading generated classes and resources

### DIFF
--- a/src/test/java/com/google/testing/compile/GeneratingProcessor.java
+++ b/src/test/java/com/google/testing/compile/GeneratingProcessor.java
@@ -51,6 +51,9 @@ final class GeneratingProcessor extends AbstractProcessor {
   public synchronized void init(ProcessingEnvironment processingEnv) {
     Filer filer = processingEnv.getFiler();
     try (Writer writer = filer.createSourceFile(generatedClassName()).openWriter()) {
+      if (!packageName.isEmpty()) {
+        writer.write("package " + packageName + ";\n");
+      }
       writer.write(GENERATED_SOURCE);
     } catch (IOException e) {
       throw new RuntimeException(e);


### PR DESCRIPTION
Add `Compilation.classLoader()` method (and an overloaded version that takes a parent classloader). The returned ClassLoader is useful for loading generated classes and resources.