### PR TITLE
Moe Sync

### DIFF
--- a/src/main/java/com/google/testing/compile/ForwardingStandardJavaFileManager.java
+++ b/src/main/java/com/google/testing/compile/ForwardingStandardJavaFileManager.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2018 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.testing.compile;
+
+import java.io.File;
+import java.io.IOException;
+import javax.tools.ForwardingJavaFileManager;
+import javax.tools.JavaFileObject;
+import javax.tools.StandardJavaFileManager;
+
+/**
+ * Forwards calls to a given {@link StandardJavaFileManager}. Subclasses of this class might
+ * override some of these methods and might also provide additional fields and methods.
+ */
+class ForwardingStandardJavaFileManager extends ForwardingJavaFileManager<StandardJavaFileManager>
+    implements StandardJavaFileManager {
+
+  /**
+   * Creates a new instance of ForwardingStandardJavaFileManager.
+   *
+   * @param fileManager delegate to this file manager
+   */
+  ForwardingStandardJavaFileManager(StandardJavaFileManager fileManager) {
+    super(fileManager);
+  }
+
+  @Override
+  public Iterable<? extends JavaFileObject> getJavaFileObjectsFromFiles(
+      Iterable<? extends File> files) {
+    return fileManager.getJavaFileObjectsFromFiles(files);
+  }
+
+  @Override
+  public Iterable<? extends JavaFileObject> getJavaFileObjects(File... files) {
+    return fileManager.getJavaFileObjects(files);
+  }
+
+  @Override
+  public Iterable<? extends JavaFileObject> getJavaFileObjects(String... names) {
+    return fileManager.getJavaFileObjects(names);
+  }
+
+  @Override
+  public Iterable<? extends JavaFileObject> getJavaFileObjectsFromStrings(Iterable<String> names) {
+    return fileManager.getJavaFileObjectsFromStrings(names);
+  }
+
+  @Override
+  public void setLocation(Location location, Iterable<? extends File> path) throws IOException {
+    fileManager.setLocation(location, path);
+  }
+
+  @Override
+  public Iterable<? extends File> getLocation(Location location) {
+    return fileManager.getLocation(location);
+  }
+}

--- a/src/main/java/com/google/testing/compile/InMemoryJavaFileManager.java
+++ b/src/main/java/com/google/testing/compile/InMemoryJavaFileManager.java
@@ -34,11 +34,10 @@ import java.net.URI;
 import java.nio.charset.Charset;
 import java.util.Map.Entry;
 import javax.tools.FileObject;
-import javax.tools.ForwardingJavaFileManager;
-import javax.tools.JavaFileManager;
 import javax.tools.JavaFileObject;
 import javax.tools.JavaFileObject.Kind;
 import javax.tools.SimpleJavaFileObject;
+import javax.tools.StandardJavaFileManager;
 import javax.tools.StandardLocation;
 
 /**
@@ -47,7 +46,7 @@ import javax.tools.StandardLocation;
  * @author Gregory Kick
  */
 // TODO(gak): under java 1.7 this could all be done with a PathFileManager
-final class InMemoryJavaFileManager extends ForwardingJavaFileManager<JavaFileManager> {
+final class InMemoryJavaFileManager extends ForwardingStandardJavaFileManager {
   private final LoadingCache<URI, JavaFileObject> inMemoryFileObjects =
       CacheBuilder.newBuilder().build(new CacheLoader<URI, JavaFileObject>() {
         @Override
@@ -56,7 +55,7 @@ final class InMemoryJavaFileManager extends ForwardingJavaFileManager<JavaFileMa
         }
       });
 
-  InMemoryJavaFileManager(JavaFileManager fileManager) {
+  InMemoryJavaFileManager(StandardJavaFileManager fileManager) {
     super(fileManager);
   }
 

--- a/src/main/java/com/google/testing/compile/JavaSourcesSubject.java
+++ b/src/main/java/com/google/testing/compile/JavaSourcesSubject.java
@@ -40,6 +40,7 @@ import com.google.testing.compile.CompilationSubject.DiagnosticInFile;
 import com.google.testing.compile.CompilationSubject.DiagnosticOnLine;
 import com.google.testing.compile.Parser.ParseResult;
 import com.sun.source.tree.CompilationUnitTree;
+import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
@@ -65,6 +66,7 @@ public final class JavaSourcesSubject
     implements CompileTester, ProcessedCompileTesterFactory {
   private final List<String> options = new ArrayList<String>(Arrays.asList("-Xlint"));
   @Nullable private ClassLoader classLoader;
+  @Nullable private ImmutableList<File> classPath;
 
   JavaSourcesSubject(FailureMetadata failureMetadata, Iterable<? extends JavaFileObject> subject) {
     super(failureMetadata, subject);
@@ -82,9 +84,21 @@ public final class JavaSourcesSubject
     return this;
   }
 
+  /**
+   * @deprecated prefer {@link #withClasspath(Iterable)}. This method only supports {@link
+   *     URLClassLoader} and the default system classloader, and {@link File}s are usually a more
+   *     natural way to expression compilation classpaths than class loaders.
+   */
+  @Deprecated
   @Override
   public JavaSourcesSubject withClasspathFrom(ClassLoader classLoader) {
     this.classLoader = classLoader;
+    return this;
+  }
+
+  @Override
+  public JavaSourcesSubject withClasspath(Iterable<File> classPath) {
+    this.classPath = ImmutableList.copyOf(classPath);
     return this;
   }
 
@@ -311,6 +325,9 @@ public final class JavaSourcesSubject
       Compiler compiler = javac().withProcessors(processors).withOptions(options);
       if (classLoader != null) {
         compiler = compiler.withClasspathFrom(classLoader);
+      }
+      if (classPath != null) {
+        compiler = compiler.withClasspath(classPath);
       }
       return compiler.compile(actual());
     }
@@ -577,9 +594,20 @@ public final class JavaSourcesSubject
       return delegate.withCompilerOptions(options);
     }
 
+    /**
+     * @deprecated prefer {@link #withClasspath(Iterable)}. This method only supports {@link
+     *     URLClassLoader} and the default system classloader, and {@link File}s are usually a more
+     *     natural way to expression compilation classpaths than class loaders.
+     */
+    @Deprecated
     @Override
     public JavaSourcesSubject withClasspathFrom(ClassLoader classLoader) {
       return delegate.withClasspathFrom(classLoader);
+    }
+
+    @Override
+    public JavaSourcesSubject withClasspath(Iterable<File> classPath) {
+      return delegate.withClasspath(classPath);
     }
 
     @Override

--- a/src/main/java/com/google/testing/compile/ProcessedCompileTesterFactory.java
+++ b/src/main/java/com/google/testing/compile/ProcessedCompileTesterFactory.java
@@ -15,6 +15,7 @@
  */
 package com.google.testing.compile;
 
+import java.io.File;
 import javax.annotation.CheckReturnValue;
 import javax.annotation.processing.Processor;
 
@@ -24,34 +25,44 @@ import javax.annotation.processing.Processor;
  *
  * @author Gregory Kick
  */
+@CheckReturnValue
 public interface ProcessedCompileTesterFactory {
 
   /**
    * Adds options that will be passed to the compiler. {@code -Xlint} is the first option, by
    * default.
    */
-  @CheckReturnValue ProcessedCompileTesterFactory withCompilerOptions(Iterable<String> options);
-  
+  ProcessedCompileTesterFactory withCompilerOptions(Iterable<String> options);
+
   /**
    * Adds options that will be passed to the compiler. {@code -Xlint} is the first option, by
    * default.
    */
-  @CheckReturnValue ProcessedCompileTesterFactory withCompilerOptions(String... options);
+  ProcessedCompileTesterFactory withCompilerOptions(String... options);
 
   /**
    * Attempts to extract the classpath from the classpath of the Classloader argument, including all
    * its parents up to (and including) the System Classloader.
-   * <p>
-   * If not specified, we will use the System classpath for compilation.
+   *
+   * <p>If not specified, we will use the System classpath for compilation.
+   *
+   * @deprecated prefer {@link #withClasspath(Iterable)}. This method only supports {@link
+   *     URLClassLoader} and the default system classloader, and {@link File}s are usually a more
+   *     natural way to expression compilation classpaths than class loaders.
    */
-  @CheckReturnValue
+  @Deprecated
   ProcessedCompileTesterFactory withClasspathFrom(ClassLoader classloader);
-  
+
+  /**
+   * Sets the compilation classpath.
+   *
+   * <p>If not specified, we will use the System classpath for compilation.
+   */
+  ProcessedCompileTesterFactory withClasspath(Iterable<File> classPath);
+
   /** Adds {@linkplain Processor annotation processors} to the compilation being tested.  */
-  @CheckReturnValue
   CompileTester processedWith(Processor first, Processor... rest);
 
   /** Adds {@linkplain Processor annotation processors} to the compilation being tested.  */
-  @CheckReturnValue
   CompileTester processedWith(Iterable<? extends Processor> processors);
 }

--- a/src/test/java/com/google/testing/compile/CompilerTest.java
+++ b/src/test/java/com/google/testing/compile/CompilerTest.java
@@ -19,6 +19,7 @@ import static com.google.common.truth.Truth.assertThat;
 import static com.google.testing.compile.CompilationSubject.assertThat;
 import static com.google.testing.compile.Compiler.javac;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assume.assumeTrue;
 
 import com.google.common.collect.ImmutableList;
 import java.io.File;
@@ -28,6 +29,7 @@ import java.net.URLClassLoader;
 import java.util.Arrays;
 import java.util.Locale;
 import javax.annotation.processing.Processor;
+import javax.lang.model.SourceVersion;
 import javax.tools.JavaCompiler;
 import javax.tools.JavaCompiler.CompilationTask;
 import javax.tools.JavaFileObject;
@@ -194,5 +196,19 @@ public final class CompilerTest {
             .withOptions("-verbose")
             .compile(JavaFileObjects.forSourceLines("Test", "class Test {", "  Lib lib;", "}"));
     assertThat(compilation).succeeded();
+  }
+
+  @Test
+  public void releaseFlag() {
+    assumeTrue(isJdk9OrLater());
+    Compilation compilation =
+        javac()
+            .withOptions("--release", "8")
+            .compile(JavaFileObjects.forSourceString("HelloWorld", "final class HelloWorld {}"));
+    assertThat(compilation).succeeded();
+  }
+
+  static boolean isJdk9OrLater() {
+    return SourceVersion.latestSupported().compareTo(SourceVersion.RELEASE_8) > 0;
   }
 }


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Add withClasspath(Iterable<File>) to Compiler and JavaSourcesSubject and deprecate withClasspathFrom(ClassLoader)

RELNOTES=Add `withClasspath(Iterable<File>)` to `Compiler` and `JavaSourcesSubject` and deprecate `withClasspathFrom(ClassLoader)`

b146a688e885d33d3df394a37e487ad4421d7348

-------

<p> Add support for --release

The flag depends on FileManager support for nio, which was added
to the API in 9.

RELNOTES=N/A

c7a49dc08c9213dc9738547c76bd89be106347e8