### PR TITLE
Add junit compilation test integration

### DIFF
--- a/src/main/java/com/google/testing/compile/junit/Compile.java
+++ b/src/main/java/com/google/testing/compile/junit/Compile.java
@@ -1,0 +1,42 @@
+package com.google.testing.compile.junit;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Annotation;
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import javax.annotation.processing.RoundEnvironment;
+import javax.lang.model.SourceVersion;
+
+/**
+ * Indicate the method is a compile period test. The test class must extends
+ * {@link CompileTestCase}.
+ *
+ * The annotated method must be public void and one argument
+ * {@link RoundEnvironment} .
+ *
+ * @author Dean Xu (XDean@github.com)
+ */
+@Retention(RUNTIME)
+@Target(METHOD)
+@Documented
+public @interface Compile {
+  /**
+   * The source files to compile. Has same rule of
+   * {@link Class#getResource(String)}.
+   */
+  String[] sources();
+
+  /**
+   * Supported annotations. Empty means '*'.
+   */
+  Class<? extends Annotation>[] annotations() default {};
+
+  /**
+   * Supported source version.
+   */
+  SourceVersion version() default SourceVersion.RELEASE_8;
+}

--- a/src/main/java/com/google/testing/compile/junit/Compile.java
+++ b/src/main/java/com/google/testing/compile/junit/Compile.java
@@ -12,11 +12,10 @@ import javax.annotation.processing.RoundEnvironment;
 import javax.lang.model.SourceVersion;
 
 /**
- * Indicate the method is a compile period test. The test class must extends
- * {@link CompileTestCase}.
- *
- * The annotated method must be public void and one argument
- * {@link RoundEnvironment} .
+ * Indicate the test method is a compile period test.
+ * 
+ * The test class must extends {@link CompileTestCase}. The method also need annotated {@code @Test}
+ * and it must be public void and have one argument with type {@link RoundEnvironment}.
  *
  * @author Dean Xu (XDean@github.com)
  */
@@ -25,8 +24,7 @@ import javax.lang.model.SourceVersion;
 @Documented
 public @interface Compile {
   /**
-   * The source files to compile. Has same rule of
-   * {@link Class#getResource(String)}.
+   * The source files to compile. Has same rule of {@link Class#getResource(String)}.
    */
   String[] sources();
 

--- a/src/main/java/com/google/testing/compile/junit/Compile.java
+++ b/src/main/java/com/google/testing/compile/junit/Compile.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2018 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.google.testing.compile.junit;
 
 import static java.lang.annotation.ElementType.METHOD;

--- a/src/main/java/com/google/testing/compile/junit/CompileTestCase.java
+++ b/src/main/java/com/google/testing/compile/junit/CompileTestCase.java
@@ -1,0 +1,79 @@
+package com.google.testing.compile.junit;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import javax.annotation.processing.AbstractProcessor;
+import javax.annotation.processing.Filer;
+import javax.annotation.processing.Messager;
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.annotation.processing.RoundEnvironment;
+import javax.lang.model.SourceVersion;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.util.Elements;
+import javax.lang.model.util.Types;
+
+import org.junit.Ignore;
+import org.junit.runner.RunWith;
+import org.junit.runners.model.FrameworkMethod;
+
+@Ignore
+@RunWith(CompileTestRunner.class)
+public class CompileTestCase extends AbstractProcessor {
+  private FrameworkMethod method;
+  private Optional<Compile> anno;
+  private Throwable error;
+
+  protected Types types;
+  protected Elements elements;
+  protected Messager messager;
+  protected Filer filer;
+
+  @Override
+  public synchronized void init(ProcessingEnvironment processingEnv) {
+    super.init(processingEnv);
+    messager = processingEnv.getMessager();
+    types = processingEnv.getTypeUtils();
+    elements = processingEnv.getElementUtils();
+    filer = processingEnv.getFiler();
+  }
+
+  public void setMethod(FrameworkMethod method) {
+    this.method = method;
+    this.anno = Optional.ofNullable(method.getAnnotation(Compile.class));
+  }
+
+  @Override
+  public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+    if (roundEnv.processingOver()) {
+      return false;
+    }
+    try {
+      method.invokeExplosively(this, roundEnv);
+    } catch (Throwable e) {
+      error = e;
+    }
+    return false;
+  }
+
+  @Override
+  public SourceVersion getSupportedSourceVersion() {
+    return anno.map(c -> c.version()).orElse(SourceVersion.RELEASE_8);
+  }
+
+  @Override
+  public Set<String> getSupportedAnnotationTypes() {
+    return anno.map(co -> Arrays.stream(co.annotations())
+        .map(c -> c.getName())
+        .collect(Collectors.toSet()))
+        .filter(s -> !s.isEmpty())
+        .orElse(Collections.singleton("*"));
+  }
+
+  public Throwable getError() {
+    return error;
+  }
+}

--- a/src/main/java/com/google/testing/compile/junit/CompileTestCase.java
+++ b/src/main/java/com/google/testing/compile/junit/CompileTestCase.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2018 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.google.testing.compile.junit;
 
 import java.util.Arrays;

--- a/src/main/java/com/google/testing/compile/junit/CompileTestCase.java
+++ b/src/main/java/com/google/testing/compile/junit/CompileTestCase.java
@@ -20,6 +20,13 @@ import org.junit.Ignore;
 import org.junit.runner.RunWith;
 import org.junit.runners.model.FrameworkMethod;
 
+/**
+ * Extends this class and use {@code @Compile} and {@code @Compiled} to do test for compilation.
+ * 
+ * @see Compile
+ * @see Compiled
+ * @author Dean Xu (XDean@github.com)
+ */
 @Ignore
 @RunWith(CompileTestRunner.class)
 public class CompileTestCase extends AbstractProcessor {

--- a/src/main/java/com/google/testing/compile/junit/CompileTestRunner.java
+++ b/src/main/java/com/google/testing/compile/junit/CompileTestRunner.java
@@ -28,7 +28,7 @@ public class CompileTestRunner extends BlockJUnit4ClassRunner {
   protected void collectInitializationErrors(List<Throwable> errors) {
     super.collectInitializationErrors(errors);
     if (!CompileTestCase.class.isAssignableFrom(getTestClass().getJavaClass())) {
-      errors.add(new Exception("CompileTestRunner must run with CompileTest"));
+      errors.add(new Exception("CompileTestRunner must run with CompileTestCase"));
     }
   }
 

--- a/src/main/java/com/google/testing/compile/junit/CompileTestRunner.java
+++ b/src/main/java/com/google/testing/compile/junit/CompileTestRunner.java
@@ -18,8 +18,15 @@ import com.google.testing.compile.Compilation;
 import com.google.testing.compile.Compiler;
 import com.google.testing.compile.JavaFileObjects;
 
+/**
+ * Runner for compilation test. It can process {@code @Compile}, {@code @Compiled} and normal junit
+ * test method.
+ * 
+ * @see Compile
+ * @see Compiled
+ * @author Dean Xu (XDean@github.com)
+ */
 public class CompileTestRunner extends BlockJUnit4ClassRunner {
-
   public CompileTestRunner(Class<?> klass) throws InitializationError {
     super(klass);
   }

--- a/src/main/java/com/google/testing/compile/junit/CompileTestRunner.java
+++ b/src/main/java/com/google/testing/compile/junit/CompileTestRunner.java
@@ -1,0 +1,119 @@
+package com.google.testing.compile.junit;
+
+import java.lang.annotation.Annotation;
+import java.util.Arrays;
+import java.util.List;
+
+import javax.annotation.processing.Processor;
+import javax.annotation.processing.RoundEnvironment;
+import javax.tools.JavaFileObject;
+
+import org.junit.Test;
+import org.junit.runners.BlockJUnit4ClassRunner;
+import org.junit.runners.model.FrameworkMethod;
+import org.junit.runners.model.InitializationError;
+import org.junit.runners.model.Statement;
+
+import com.google.testing.compile.Compilation;
+import com.google.testing.compile.Compiler;
+import com.google.testing.compile.JavaFileObjects;
+
+public class CompileTestRunner extends BlockJUnit4ClassRunner {
+
+  public CompileTestRunner(Class<?> klass) throws InitializationError {
+    super(klass);
+  }
+
+  @Override
+  protected void collectInitializationErrors(List<Throwable> errors) {
+    super.collectInitializationErrors(errors);
+    if (!CompileTestCase.class.isAssignableFrom(getTestClass().getJavaClass())) {
+      errors.add(new Exception("CompileTestRunner must run with CompileTest"));
+    }
+  }
+
+  @Override
+  protected void validateTestMethods(List<Throwable> errors) {
+    validatePublicVoidNoArgMethods(Test.class, false, errors);
+  }
+
+  @Override
+  protected Statement methodInvoker(FrameworkMethod method, Object test) {
+    CompileTestCase ct = (CompileTestCase) test;
+    if (method.getMethod().isAnnotationPresent(Compile.class)) {
+      ct.setMethod(method);
+      return new Statement() {
+        @Override
+        public void evaluate() throws Throwable {
+          // Compile compile = AnnotationUtils.getAnnotation(method.getMethod(), Compile.class);
+          Compile compile = method.getMethod().getAnnotation(Compile.class);
+          Class<?> clz = getTestClass().getJavaClass();
+          Compiler.javac()
+              .withProcessors(ct)
+              .compile(Arrays.stream(compile.sources())
+                  .map(s -> clz.getResource(s))
+                  .map(u -> JavaFileObjects.forResource(u))
+                  .toArray(JavaFileObject[]::new));
+          if (ct.getError() != null) {
+            throw ct.getError();
+          }
+        }
+      };
+    } else if (method.getMethod().isAnnotationPresent(Compiled.class)) {
+      return new Statement() {
+        @Override
+        public void evaluate() throws Throwable {
+          // Compiled compiled = AnnotationUtils.getAnnotation(method.getMethod(), Compiled.class);
+          Compiled compiled = method.getMethod().getAnnotation(Compiled.class);
+          Class<?> clz = getTestClass().getJavaClass();
+          Compilation compilation = Compiler.javac()
+              .withProcessors(Arrays.stream(compiled.processors())
+                  .map(c -> {
+                    try {
+                      return c.newInstance();
+                    } catch (Exception e) {
+                      throw new IllegalStateException("Annotation Processor must has no-arg public constructor");
+                    }
+                  })
+                  .toArray(Processor[]::new))
+              .withOptions(Arrays.stream(compiled.options()).toArray(Object[]::new))
+              .compile(Arrays.stream(compiled.sources())
+                  .map(s -> clz.getResource(s))
+                  .map(u -> JavaFileObjects.forResource(u))
+                  .toArray(JavaFileObject[]::new));
+          method.invokeExplosively(ct, compilation);
+        }
+      };
+    } else {
+      return super.methodInvoker(method, test);
+    }
+  }
+
+  @Override
+  protected void validatePublicVoidNoArgMethods(Class<? extends Annotation> annotation, boolean isStatic,
+      List<Throwable> errors) {
+    List<FrameworkMethod> methods = getTestClass().getAnnotatedMethods(annotation);
+    for (FrameworkMethod method : methods) {
+      method.validatePublicVoid(isStatic, errors);
+      boolean compile = method.getMethod().isAnnotationPresent(Compile.class);
+      boolean compiled = method.getMethod().isAnnotationPresent(Compiled.class);
+      if (compile && compiled) {
+        errors.add(new Exception("Method " + method.getName() + " can't annotated both @Compile and @Compiled"));
+      } else if (compile) {
+        int count = method.getMethod().getParameterCount();
+        if (count != 1 || !method.getMethod().getParameterTypes()[0].isAssignableFrom(RoundEnvironment.class)) {
+          errors.add(new Exception(
+              "Method " + method.getName() + " must have only one param with type RoundEnvironment"));
+        }
+      } else if (compiled) {
+        int count = method.getMethod().getParameterCount();
+        if (count != 1 || !method.getMethod().getParameterTypes()[0].isAssignableFrom(Compilation.class)) {
+          errors.add(new Exception(
+              "Method " + method.getName() + " must have only one param with type Compilation"));
+        }
+      } else {
+        method.validatePublicVoidNoArg(isStatic, errors);
+      }
+    }
+  }
+}

--- a/src/main/java/com/google/testing/compile/junit/CompileTestRunner.java
+++ b/src/main/java/com/google/testing/compile/junit/CompileTestRunner.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2018 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.google.testing.compile.junit;
 
 import java.lang.annotation.Annotation;

--- a/src/main/java/com/google/testing/compile/junit/Compiled.java
+++ b/src/main/java/com/google/testing/compile/junit/Compiled.java
@@ -1,0 +1,42 @@
+package com.google.testing.compile.junit;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import javax.annotation.processing.Processor;
+
+import com.google.testing.compile.Compilation;
+
+/**
+ * Indicate the method is a compiled test. The test class must extends
+ * {@link CompileTestCase}.
+ *
+ * The annotated method must be public void and one argument
+ * {@link Compilation}.
+ *
+ * @author Dean Xu (XDean@github.com)
+ */
+@Retention(RUNTIME)
+@Target(METHOD)
+@Documented
+public @interface Compiled {
+  /**
+   * The source files to compile. Has same rule of
+   * {@link Class#getResource(String)}.
+   */
+  String[] sources();
+
+  /**
+   * Processors to use in this compile.
+   */
+  Class<? extends Processor>[] processors() default {};
+
+  /**
+   * Options to use in this compile. Should starts with "-A".
+   */
+  String[] options() default {};
+}

--- a/src/main/java/com/google/testing/compile/junit/Compiled.java
+++ b/src/main/java/com/google/testing/compile/junit/Compiled.java
@@ -12,11 +12,10 @@ import javax.annotation.processing.Processor;
 import com.google.testing.compile.Compilation;
 
 /**
- * Indicate the method is a compiled test. The test class must extends
- * {@link CompileTestCase}.
- *
- * The annotated method must be public void and one argument
- * {@link Compilation}.
+ * Indicate the test method is a compiled test.
+ * 
+ * The test class must extends {@link CompileTestCase}. The method also need annotated {@code @Test}
+ * and it must be public void and have only one argument with type {@link Compilation}.
  *
  * @author Dean Xu (XDean@github.com)
  */
@@ -25,18 +24,17 @@ import com.google.testing.compile.Compilation;
 @Documented
 public @interface Compiled {
   /**
-   * The source files to compile. Has same rule of
-   * {@link Class#getResource(String)}.
+   * The source files to compile. Has same rule of {@link Class#getResource(String)}.
    */
   String[] sources();
 
   /**
-   * Processors to use in this compile.
+   * Processors to use in this compile. Every class must have public no-arg constructor.
    */
   Class<? extends Processor>[] processors() default {};
 
   /**
-   * Options to use in this compile. Should starts with "-A".
+   * Options to use in this compile. Should be like "-Akey=value".
    */
   String[] options() default {};
 }

--- a/src/main/java/com/google/testing/compile/junit/Compiled.java
+++ b/src/main/java/com/google/testing/compile/junit/Compiled.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2018 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.google.testing.compile.junit;
 
 import static java.lang.annotation.ElementType.METHOD;

--- a/src/main/java/com/google/testing/compile/junit/package-info.java
+++ b/src/main/java/com/google/testing/compile/junit/package-info.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2018 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /**
  * Framework to quick build compile test in junit.
  * 

--- a/src/main/java/com/google/testing/compile/junit/package-info.java
+++ b/src/main/java/com/google/testing/compile/junit/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * @author Dean Xu (XDean@github.com)
+ */
+package com.google.testing.compile.junit;

--- a/src/main/java/com/google/testing/compile/junit/package-info.java
+++ b/src/main/java/com/google/testing/compile/junit/package-info.java
@@ -1,4 +1,33 @@
 /**
+ * Framework to quick build compile test in junit.
+ * 
+ * <ol>
+ * <li>Compile period test. Use {@code @Compile} on your test method.
+ * 
+ * <pre>
+ * &#64;Test
+ * &#64;Compile(sources = "/HelloWorld.java")
+ * public void test(RoundEnvironment env) {
+ *   // Now you are in compile (Annotation Processor) context which is compiling your sources.
+ * }
+ * </pre>
+ * 
+ * </li>
+ * 
+ * <li>Compilation test. Use {@code @Compiled} on your test method.
+ * 
+ * <pre>
+ * &#64;Test
+ * &#64;Compiled(sources = "/HelloWorld.java")
+ * public void test(Compilation c) {
+ *   // Now your sources have been compiled.
+ *   // Do assert on the Compilation.
+ * }
+ * </pre>
+ * 
+ * </li>
+ * <ol>
+ * 
  * @author Dean Xu (XDean@github.com)
  */
 package com.google.testing.compile.junit;

--- a/src/test/java/com/google/testing/compile/JunitCompileTest.java
+++ b/src/test/java/com/google/testing/compile/JunitCompileTest.java
@@ -1,0 +1,166 @@
+package com.google.testing.compile;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Collections;
+
+import javax.annotation.processing.RoundEnvironment;
+
+import org.junit.Test;
+import org.junit.runner.JUnitCore;
+import org.junit.runner.Result;
+import org.junit.runner.RunWith;
+
+import com.google.testing.compile.junit.Compile;
+import com.google.testing.compile.junit.CompileTestCase;
+import com.google.testing.compile.junit.CompileTestRunner;
+import com.google.testing.compile.junit.Compiled;
+
+public class JunitCompileTest {
+
+  public static class CompileGolden extends CompileTestCase {
+    @Test
+    @Compile(sources = "/HelloWorld.java")
+    public void test(RoundEnvironment env) throws Exception {
+    }
+
+    @Test
+    @Compile(sources = "/HelloWorld.java", annotations = Compile.class)
+    public void test2(RoundEnvironment env) throws Exception {
+    }
+
+    @Test
+    public void normal() throws Exception {
+    }
+  }
+
+  @Test
+  public void testCompileGolden() throws Exception {
+    success(CompileGolden.class);
+  }
+
+  public static class CompiledGolden extends CompileTestCase {
+    @Test
+    @Compiled(sources = "/HelloWorld.java", processors = PublicNoOpProcessor.class, options = "-Atest=true")
+    public void test(Compilation c) throws Exception {
+      NoOpProcessor noOpProcessor = (NoOpProcessor) c.compiler().processors().get(0);
+      assertTrue(noOpProcessor.invoked);
+      assertEquals(Collections.singletonMap("test", "true"), noOpProcessor.options);
+    }
+  }
+
+  @Test
+  public void testCompiledGolden() throws Exception {
+    success(CompiledGolden.class);
+  }
+
+  public static class CompileNoArg extends CompileTestCase {
+    @Test
+    @Compile(sources = "/HelloWorld.java")
+    public void test() throws Exception {
+    }
+  }
+
+  @Test
+  public void testCompileNoArg() throws Exception {
+    fail(CompileNoArg.class, "RoundEnvironment");
+  }
+
+  public static class CompiledNoArg extends CompileTestCase {
+    @Test
+    @Compiled(sources = "/HelloWorld.java")
+    public void test() throws Exception {
+    }
+  }
+
+  @Test
+  public void testCompiledNoArg() throws Exception {
+    fail(CompiledNoArg.class, "Compilation");
+  }
+
+  public static class CompileWrongArg extends CompileTestCase {
+    @Test
+    @Compile(sources = "/HelloWorld.java")
+    public void test(Compilation c) throws Exception {
+    }
+  }
+
+  @Test
+  public void testCompileWrongArg() throws Exception {
+    fail(CompileWrongArg.class, "RoundEnvironment");
+  }
+
+  public static class CompiledWrongArg extends CompileTestCase {
+    @Test
+    @Compiled(sources = "/HelloWorld.java")
+    public void test(RoundEnvironment env) throws Exception {
+    }
+  }
+
+  @Test
+  public void testCompiledWrongArg() throws Exception {
+    fail(CompiledWrongArg.class, "Compilation");
+  }
+
+  public static class Both extends CompileTestCase {
+    @Test
+    @Compiled(sources = "/HelloWorld.java")
+    @Compile(sources = "/HelloWorld.java")
+    public void test(RoundEnvironment env) throws Exception {
+    }
+  }
+
+  @Test
+  public void testBoth() throws Exception {
+    fail(Both.class, "both");
+  }
+
+  @RunWith(CompileTestRunner.class)
+  public static class NotCompileTestCase {
+    @Test
+    @Compile(sources = "/HelloWorld.java")
+    public void test(RoundEnvironment env) throws Exception {
+    }
+  }
+
+  @Test
+  public void testNotCompileTestCase() throws Exception {
+    fail(NotCompileTestCase.class, "CompileTestCase");
+  }
+
+  public static class CompileError extends CompileTestCase {
+    @Test
+    @Compile(sources = "/HelloWorld.java")
+    public void test(RoundEnvironment env) throws Exception {
+      throw new Exception("CompileError");
+    }
+  }
+
+  @Test
+  public void testCompileError() throws Exception {
+    fail(CompileError.class, "CompileError");
+  }
+
+  public static class ProcessorConstructError extends CompileTestCase {
+    @Test
+    @Compiled(sources = "/HelloWorld.java", processors = NoOpProcessor.class)
+    public void test(Compilation c) throws Exception {
+    }
+  }
+
+  @Test
+  public void testProcessorConstructError() throws Exception {
+    fail(ProcessorConstructError.class, "constructor");
+  }
+
+  private void success(Class<?> clz) {
+    assertTrue(JUnitCore.runClasses(clz).getFailureCount() == 0);
+  }
+
+  private void fail(Class<?> clz, String message) {
+    Result result = JUnitCore.runClasses(clz);
+    assertTrue(result.getFailureCount() == 1);
+    assertTrue(result.getFailures().get(0).getMessage().contains(message));
+  }
+}

--- a/src/test/java/com/google/testing/compile/JunitCompileTest.java
+++ b/src/test/java/com/google/testing/compile/JunitCompileTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2018 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.google.testing.compile;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/com/google/testing/compile/NoOpProcessor.java
+++ b/src/test/java/com/google/testing/compile/NoOpProcessor.java
@@ -25,7 +25,7 @@ import javax.annotation.processing.RoundEnvironment;
 import javax.lang.model.SourceVersion;
 import javax.lang.model.element.TypeElement;
 
-final class NoOpProcessor extends AbstractProcessor {
+class NoOpProcessor extends AbstractProcessor {
   boolean invoked = false;
   Map<String, String> options;
 

--- a/src/test/java/com/google/testing/compile/PublicNoOpProcessor.java
+++ b/src/test/java/com/google/testing/compile/PublicNoOpProcessor.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2013 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.testing.compile;
+
+public class PublicNoOpProcessor extends NoOpProcessor {
+  public PublicNoOpProcessor() {
+  }
+}


### PR DESCRIPTION
Add support to quick build compile-period or compilation test in JUnit.

1. Compile period test. Use `@Compile` on your test method. 
```
@Test
@Compile(sources = "/HelloWorld.java")
public void test(RoundEnvironment env) {
  // Now you are in compile (Annotation Processor) context which is compiling your sources.
}
```
 

2. Compilation test. Use `@Compiled` on your test method. 
```
@Test
@Compiled(sources = "/HelloWorld.java")
public void test(Compilation c) {
  // Now your sources have been compiled.
  // Do assert on the Compilation.
}
```

- [x] [CI passed](https://travis-ci.org/XDean/compile-testing)
- [x] Test coverage for new files: 100%
- [x] Use Samples: [Sample 1](https://github.com/XDean/AnnotationProcessorToolkit/blob/57e095148a10c0de03ba2e154c3f891d82684882/src/test/java/xdean/annotation/processor/toolkit/ElementUtilTest.java), [Sample 2](https://github.com/XDean/deannotation-checker/blob/21d630ef0c21cca69c9fe8df0c1287b56041c935/src/test/java/xdean/deannotation/checker/AssertChildrenTest.java)