### PR TITLE
Moe Sync

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
   <description>Utilities for testing compilation.</description>
 
   <properties>
-    <truth.version>0.37</truth.version>
+    <truth.version>0.41</truth.version>
   </properties>
 
   <url>http://github.com/google/compile-testing</url>
@@ -65,7 +65,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>23.6-jre</version>
+      <version>25.1-jre</version>
     </dependency>
     <dependency>
       <groupId>com.google.code.findbugs</groupId>

--- a/src/main/java/com/google/testing/compile/CompilationSubject.java
+++ b/src/main/java/com/google/testing/compile/CompilationSubject.java
@@ -19,6 +19,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Predicates.notNull;
 import static com.google.common.collect.Iterables.size;
 import static com.google.common.collect.Streams.mapWithIndex;
+import static com.google.common.truth.Fact.simpleFact;
 import static com.google.common.truth.Truth.assertAbout;
 import static com.google.testing.compile.Compilation.Status.FAILURE;
 import static com.google.testing.compile.Compilation.Status.SUCCESS;
@@ -76,8 +77,9 @@ public final class CompilationSubject extends Subject<CompilationSubject, Compil
   /** Asserts that the compilation succeeded. */
   public void succeeded() {
     if (actual().status().equals(FAILURE)) {
-      failWithRawMessage(
-          actual().describeFailureDiagnostics() + actual().describeGeneratedSourceFiles());
+      failWithoutActual(
+          simpleFact(
+              actual().describeFailureDiagnostics() + actual().describeGeneratedSourceFiles()));
     }
   }
 
@@ -90,9 +92,10 @@ public final class CompilationSubject extends Subject<CompilationSubject, Compil
   /** Asserts that the compilation failed. */
   public void failed() {
     if (actual().status().equals(SUCCESS)) {
-      failWithRawMessage(
-          "Compilation was expected to fail, but contained no errors.\n\n"
-              + actual().describeGeneratedSourceFiles());
+      failWithoutActual(
+          simpleFact(
+              "Compilation was expected to fail, but contained no errors.\n\n"
+                  + actual().describeGeneratedSourceFiles()));
     }
   }
 
@@ -171,14 +174,15 @@ public final class CompilationSubject extends Subject<CompilationSubject, Compil
         actual().diagnosticsOfKind(kind, more);
     int actualCount = size(diagnostics);
     if (actualCount != expectedCount) {
-      failWithRawMessage(
-          messageListing(
-              diagnostics,
-              "Expected %d %s, but found the following %d %s:",
-              expectedCount,
-              kindPlural(kind),
-              actualCount,
-              kindPlural(kind)));
+      failWithoutActual(
+          simpleFact(
+              messageListing(
+                  diagnostics,
+                  "Expected %d %s, but found the following %d %s:",
+                  expectedCount,
+                  kindPlural(kind),
+                  actualCount,
+                  kindPlural(kind))));
     }
   }
 
@@ -283,8 +287,10 @@ public final class CompilationSubject extends Subject<CompilationSubject, Compil
             .filter(diagnostic -> expectedPattern.matcher(diagnostic.getMessage(null)).find())
             .collect(toImmutableList());
     if (diagnosticsWithMessage.isEmpty()) {
-      failWithRawMessage(
-          messageListing(diagnosticsOfKind, "Expected %s, but only found:", expectedDiagnostic));
+      failWithoutActual(
+          simpleFact(
+              messageListing(
+                  diagnosticsOfKind, "Expected %s, but only found:", expectedDiagnostic)));
     }
     return diagnosticsWithMessage;
   }
@@ -375,11 +381,12 @@ public final class CompilationSubject extends Subject<CompilationSubject, Compil
     }
 
     protected void failExpectingMatchingDiagnostic(String format, Object... args) {
-      failWithRawMessage(
-          new StringBuilder("Expected ")
-              .append(expectedDiagnostic)
-              .append(String.format(format, args))
-              .toString());
+      failWithoutActual(
+          simpleFact(
+              new StringBuilder("Expected ")
+                  .append(expectedDiagnostic)
+                  .append(String.format(format, args))
+                  .toString()));
     }
   }
 

--- a/src/main/java/com/google/testing/compile/JavaSourcesSubject.java
+++ b/src/main/java/com/google/testing/compile/JavaSourcesSubject.java
@@ -15,6 +15,7 @@
  */
 package com.google.testing.compile;
 
+import static com.google.common.truth.Fact.simpleFact;
 import static com.google.common.truth.Truth.assertAbout;
 import static com.google.testing.compile.CompilationSubject.compilations;
 import static com.google.testing.compile.Compiler.javac;
@@ -150,8 +151,9 @@ public final class JavaSourcesSubject
     @Override
     public void parsesAs(JavaFileObject first, JavaFileObject... rest) {
       if (Iterables.isEmpty(actual())) {
-        failWithRawMessage(
-            "Compilation generated no additional source files, though some were expected.");
+        failWithoutActual(
+            simpleFact(
+                "Compilation generated no additional source files, though some were expected."));
         return;
       }
       ParseResult actualResult = Parser.parse(actual());
@@ -163,7 +165,7 @@ public final class JavaSourcesSubject
           message.append('\n');
           message.append(error);
         }
-        failWithRawMessage(message.toString());
+        failWithoutActual(simpleFact(message.toString()));
         return;
       }
       final ParseResult expectedResult = Parser.parse(Lists.asList(first, rest));
@@ -246,51 +248,54 @@ public final class JavaSourcesSubject
                             }
                           })
                       .toList());
-      failWithRawMessage(
-          Joiner.on('\n')
-              .join(
-                  "",
-                  "An expected source declared one or more top-level types that were not present.",
-                  "",
-                  String.format("Expected top-level types: <%s>", expectedTypes),
-                  String.format(
-                      "Declared by expected file: <%s>",
-                      expectedTree.getSourceFile().toUri().getPath()),
-                  "",
-                  "The top-level types that were present are as follows: ",
-                  "",
-                  generatedTypesReport,
-                  ""));
+      failWithoutActual(
+          simpleFact(
+              Joiner.on('\n')
+                  .join(
+                      "",
+                      "An expected source declared one or more top-level types that were not "
+                          + "present.",
+                      "",
+                      String.format("Expected top-level types: <%s>", expectedTypes),
+                      String.format(
+                          "Declared by expected file: <%s>",
+                          expectedTree.getSourceFile().toUri().getPath()),
+                      "",
+                      "The top-level types that were present are as follows: ",
+                      "",
+                      generatedTypesReport,
+                      "")));
     }
 
     /** Called when the {@code generatesSources()} verb fails with a diff candidate. */
     private void failWithCandidate(
         JavaFileObject expectedSource, JavaFileObject actualSource, String diffReport) {
       try {
-        failWithRawMessage(
-            Joiner.on('\n')
-                .join(
-                    "",
-                    "Source declared the same top-level types of an expected source, but",
-                    "didn't match exactly.",
-                    "",
-                    String.format("Expected file: <%s>", expectedSource.toUri().getPath()),
-                    String.format("Actual file: <%s>", actualSource.toUri().getPath()),
-                    "",
-                    "Diffs:",
-                    "======",
-                    "",
-                    diffReport,
-                    "",
-                    "Expected Source: ",
-                    "================",
-                    "",
-                    expectedSource.getCharContent(false).toString(),
-                    "",
-                    "Actual Source:",
-                    "=================",
-                    "",
-                    actualSource.getCharContent(false).toString()));
+        failWithoutActual(
+            simpleFact(
+                Joiner.on('\n')
+                    .join(
+                        "",
+                        "Source declared the same top-level types of an expected source, but",
+                        "didn't match exactly.",
+                        "",
+                        String.format("Expected file: <%s>", expectedSource.toUri().getPath()),
+                        String.format("Actual file: <%s>", actualSource.toUri().getPath()),
+                        "",
+                        "Diffs:",
+                        "======",
+                        "",
+                        diffReport,
+                        "",
+                        "Expected Source: ",
+                        "================",
+                        "",
+                        expectedSource.getCharContent(false).toString(),
+                        "",
+                        "Actual Source:",
+                        "=================",
+                        "",
+                        actualSource.getCharContent(false).toString())));
       } catch (IOException e) {
         throw new IllegalStateException(
             "Couldn't read from JavaFileObject when it was already " + "in memory.", e);
@@ -471,8 +476,8 @@ public final class JavaSourcesSubject
     public T generatesFiles(JavaFileObject first, JavaFileObject... rest) {
       for (JavaFileObject expected : Lists.asList(first, rest)) {
         if (!wasGenerated(expected)) {
-          failWithRawMessage(
-              "Did not find a generated file corresponding to " + expected.getName());
+          failWithoutActual(
+              simpleFact("Did not find a generated file corresponding to " + expected.getName()));
         }
       }
       return thisObject();


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Migrate callers of Truth's Subject.failWithRawMessage to Subject.failWithoutActual

Requires the use of Guava 25.1 for Strings.lenientFormat and Truth 0.41 for Subject.failWithoutActual

RELNOTES: Migrated from Subject.failWithRawMessage to Subject.failWithoutActual

727c17155c5711575d53a9db2e5d614d3560466b