### PR TITLE
Moe Sync

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
   <description>Utilities for testing compilation.</description>
 
   <properties>
-    <truth.version>0.41</truth.version>
+    <truth.version>0.42</truth.version>
   </properties>
 
   <url>http://github.com/google/compile-testing</url>
@@ -61,6 +61,7 @@
       <groupId>com.google.truth.extensions</groupId>
       <artifactId>truth-java8-extension</artifactId>
       <version>${truth.version}</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Truth dependency hygiene:

- Bump Truth version to https://github.com/google/truth/releases/tag/release_0_42 (which mainly just improves Truth's own dependencies).
- Move Java 8 Truth extensions to test scope. They're used only from CompilationTest.

1f45345442f5948cfb319ec59436f1f722010d4b