### PR TITLE
Add JUnit5 implementation of CompilationRule

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,7 @@
 
   <properties>
     <truth.version>0.42</truth.version>
+    <junit5.version>5.3.1</junit5.version>
   </properties>
 
   <url>http://github.com/google/compile-testing</url>
@@ -51,6 +52,24 @@
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.12</version>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <version>${junit5.version}</version>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.platform</groupId>
+      <artifactId>junit-platform-runner</artifactId>
+      <version>1.3.1</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <version>${junit5.version}</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.google.truth</groupId>

--- a/src/main/java/com/google/testing/compile/CompilationExtension.java
+++ b/src/main/java/com/google/testing/compile/CompilationExtension.java
@@ -1,0 +1,244 @@
+/*
+ * Copyright (C) 2018 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.testing.compile;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.testing.compile.Compilation.Status.SUCCESS;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.Extension;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+import org.junit.jupiter.api.extension.ParameterResolver;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Phaser;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import javax.annotation.processing.AbstractProcessor;
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.annotation.processing.RoundEnvironment;
+import javax.lang.model.SourceVersion;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.util.Elements;
+import javax.lang.model.util.Types;
+import javax.tools.JavaFileObject;
+
+/**
+ * A Junit 5 {@link Extension} that extends a test suite such that an instance of {@link Elements}
+ * and {@link Types} are available through parameter injection during execution.
+ *
+ * <p>To use this extension, request it with {@link ExtendWith} and add the required parameters:
+ *
+ * <pre>
+ * {@code @ExtendWith}(CompilationExtension.class)
+ * class CompilerTest {
+ *   {@code @Test} void testElements({@link Elements} elements, {@link Types} types) {
+ *     // Any methods of the supplied utility classes can now be accessed.
+ *   }
+ * }
+ * </pre>
+ *
+ * @author David van Leusen
+ */
+public class CompilationExtension
+    implements BeforeAllCallback, AfterAllCallback, ParameterResolver {
+  private static final JavaFileObject DUMMY =
+      JavaFileObjects.forSourceLines("Dummy", "final class Dummy {}");
+  private static final ExtensionContext.Namespace NAMESPACE =
+      ExtensionContext.Namespace.create(CompilationExtension.class);
+  private static final Map<Class<?>, Function<ProcessingEnvironment, ?>> SUPPORTED_PARAMETERS;
+  private static final Function<ProcessingEnvironment, ?> RETURN_NULL = ignored -> null;
+
+  private static final StoreAccessor<Phaser> PHASER_KEY = new StoreAccessor<>(Phaser.class);
+  private static final StoreAccessor<AtomicReference<ProcessingEnvironment>> PROCESSINGENV_KEY =
+      new StoreAccessor<>(ProcessingEnvironment.class);
+  private static final StoreAccessor<CompletionStage<Compilation>> RESULT_KEY =
+      new StoreAccessor<>(Compilation.class);
+
+  static {
+    SUPPORTED_PARAMETERS = ImmutableMap.<Class<?>, Function<ProcessingEnvironment, ?>>builder()
+        .put(Elements.class, ProcessingEnvironment::getElementUtils)
+        .put(Types.class, ProcessingEnvironment::getTypeUtils)
+        .build();
+  }
+
+  @Override
+  public void beforeAll(ExtensionContext context) {
+    final Phaser sharedBarrier = new Phaser(2) {
+      @Override
+      protected boolean onAdvance(int phase, int parties) {
+        // Terminate the phaser once all parties have deregistered
+        return parties == 0;
+      }
+    };
+
+    final AtomicReference<ProcessingEnvironment> sharedState
+        = new AtomicReference<>(null);
+
+    final CompletionStage<Compilation> futureResult = doOneShotExecution(() ->
+        Compiler.javac()
+            .withProcessors(new EvaluatingProcessor(sharedBarrier, sharedState))
+            .compile(DUMMY)
+    );
+
+    final ExtensionContext.Store store = context.getStore(NAMESPACE);
+    PHASER_KEY.put(store, sharedBarrier);
+    PROCESSINGENV_KEY.put(store, sharedState);
+    RESULT_KEY.put(store, futureResult);
+
+    // Wait until the processor is ready for testing
+    sharedBarrier.arriveAndAwaitAdvance();
+
+    checkState(!sharedBarrier.isTerminated(), "Phaser terminated early");
+  }
+
+  @Override
+  public void afterAll(ExtensionContext context) throws Exception {
+    final ExtensionContext.Store store = context.getStore(NAMESPACE);
+    final Phaser sharedPhaser = PHASER_KEY.get(store);
+
+    // Allow the processor to finish
+    sharedPhaser.arriveAndDeregister();
+
+    // Perform status checks, since processing is 'over' almost instantly
+    final Compilation compilation = RESULT_KEY.get(store)
+        .toCompletableFuture().get(1, TimeUnit.SECONDS);
+    checkState(compilation.status().equals(SUCCESS), compilation);
+
+    // Check precondition
+    checkState(sharedPhaser.isTerminated(), "Phaser not terminated");
+  }
+
+  @Override
+  public boolean supportsParameter(
+      ParameterContext parameterContext,
+      ExtensionContext extensionContext
+  ) throws ParameterResolutionException {
+    final Class<?> parameterType = parameterContext.getParameter().getType();
+    return SUPPORTED_PARAMETERS.containsKey(parameterType);
+  }
+
+  @Override
+  public Object resolveParameter(
+      ParameterContext parameterContext,
+      ExtensionContext extensionContext
+  ) throws ParameterResolutionException {
+    final ExtensionContext.Store store = extensionContext.getStore(NAMESPACE);
+    final AtomicReference<ProcessingEnvironment> processingEnvironment
+        = PROCESSINGENV_KEY.get(store);
+
+    return SUPPORTED_PARAMETERS.getOrDefault(
+        parameterContext.getParameter().getType(),
+        RETURN_NULL
+    ).apply(checkNotNull(
+        processingEnvironment.get(),
+        "ProcessingEnvironment not available: %s",
+        RESULT_KEY.get(store)
+    ));
+  }
+
+  private <R> CompletionStage<R> doOneShotExecution(Supplier<R> run) {
+    final ExecutorService service = Executors.newSingleThreadExecutor();
+    final CompletionStage<R> future = CompletableFuture.supplyAsync(run, service);
+    // Do not accept more actions, just execute the runnable and clean up
+    service.shutdown();
+    return future;
+  }
+
+  /**
+   * Utility class to safely access {@link ExtensionContext.Store} when dealing with
+   * parameterized types.
+   */
+  static final class StoreAccessor<R> {
+    private final Object key;
+
+    StoreAccessor(Object key) {
+      this.key = key;
+    }
+
+    @SuppressWarnings("unchecked")
+    R get(ExtensionContext.Store store) {
+      return (R) store.get(key);
+    }
+
+    void put(ExtensionContext.Store store, R value) {
+      store.put(key, value);
+    }
+  }
+
+  static final class EvaluatingProcessor extends AbstractProcessor {
+    private final Phaser barrier;
+    private final AtomicReference<ProcessingEnvironment> sharedState;
+
+    EvaluatingProcessor(
+        Phaser barrier,
+        AtomicReference<ProcessingEnvironment> sharedState
+    ) {
+      this.barrier = barrier;
+      this.sharedState = sharedState;
+    }
+
+    @Override
+    public SourceVersion getSupportedSourceVersion() {
+      return SourceVersion.latest();
+    }
+
+    @Override
+    public Set<String> getSupportedAnnotationTypes() {
+      return ImmutableSet.of("*");
+    }
+
+    @Override
+    public synchronized void init(ProcessingEnvironment processingEnvironment) {
+      super.init(processingEnvironment);
+
+      // Share the processing environment
+      if (!sharedState.compareAndSet(null, processingEnvironment)) {
+        // Invalid state, init() run twice
+        barrier.forceTermination();
+        throw new IllegalStateException("Processor initialized twice");
+      }
+    }
+
+    @Override
+    public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+      if (roundEnv.processingOver()) {
+        // Synchronize on the beginning of the test run
+        barrier.arriveAndAwaitAdvance();
+
+        // Now wait until testing is over
+        barrier.awaitAdvance(barrier.arriveAndDeregister());
+
+        // Clean up the shared state
+        sharedState.getAndSet(null);
+      }
+      return false;
+    }
+  }
+}

--- a/src/test/java/com/google/testing/compile/CompilationExtensionTest.java
+++ b/src/test/java/com/google/testing/compile/CompilationExtensionTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2018 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.testing.compile;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.platform.runner.JUnitPlatform;
+import org.junit.runner.RunWith;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.util.Elements;
+import javax.lang.model.util.Types;
+
+/**
+ * Tests the {@link CompilationExtension} by applying it to this test.
+ */
+@RunWith(JUnitPlatform.class)
+@ExtendWith(CompilationExtension.class)
+public class CompilationExtensionTest {
+  private final AtomicInteger executions = new AtomicInteger();
+
+  @Test public void testMethodsExecuteExactlyOnce() {
+    assertThat(executions.getAndIncrement()).isEqualTo(0);
+  }
+
+  @BeforeEach /* we also make sure that getElements works in a @Before method */
+  @Test public void getElements(Elements elements) {
+    assertThat(elements).isNotNull();
+  }
+
+  @BeforeEach /* we also make sure that getTypes works in a @Before method */
+  @Test public void getTypes(Types types) {
+    assertThat(types).isNotNull();
+  }
+
+  /**
+   * Do some non-trivial operation with {@link Element} instances because they stop working after
+   * compilation stops.
+   */
+  @Test public void elementsAreValidAndWorking(Elements elements) {
+    TypeElement stringElement = elements.getTypeElement(String.class.getName());
+    assertThat(stringElement.getEnclosingElement())
+        .isEqualTo(elements.getPackageElement("java.lang"));
+  }
+
+  /**
+   * Do some non-trivial operation with {@link TypeMirror} instances because they stop working after
+   * compilation stops.
+   */
+  @Test public void typeMirrorsAreValidAndWorking(Elements elements, Types types) {
+    DeclaredType arrayListOfString = types.getDeclaredType(
+        elements.getTypeElement(ArrayList.class.getName()),
+        elements.getTypeElement(String.class.getName()).asType());
+    DeclaredType listOfExtendsObjectType = types.getDeclaredType(
+        elements.getTypeElement(List.class.getName()),
+        types.getWildcardType(elements.getTypeElement(Object.class.getName()).asType(), null));
+    assertThat(types.isAssignable(arrayListOfString, listOfExtendsObjectType)).isTrue();
+  }
+}


### PR DESCRIPTION
This commit adds a JUnit5 extension based on the existing `CompilationRule`

Because of the difference between JUnit4 `Rule` and JUnit5 `Extension` it is not a straightforward conversion, but the tests are just a straight copy since the primary difficulty due to the asynchronous nature of JUnit5:

- `Elements` and `Types` are only available inside of a `Processor`. Because JUnit5 does not allow extensions to take direct control of the execution of tests this required a workaround where the compiler is executed on a separate thread and then blocked while the tests are running, passing over the `ProcessingEnvironment` during that span of time.
- The extension uses `ParameterResolver` to inject `Elements` and `Types` directly as parameters to the method when they are required. This should also be compatible with other parameter injecting extensions like `@ParameterizedTest`. Accessing them as methods like `CompilationRule` does would not work since JUnit5 strongly recommends that all extensions store their state inside of `ExtensionContext.Store`, which the tests themselves cannot directly access.
- Unlike `CompilationRule` the extension runs a single compilation for the entire set of tests. Since the input of the compiler does not change I believe this would not lead to invalid results. If running a compilation for each separate test is required then the only change that needs to be made is replacing `(Before/After)All` with `(Before/After)Each`.
- The JUnit5 api dependency is marked as optional so it does not clutter the classpath when users do not use JUnit5. I'd apply this to the existing JUnit4 dependency as well but that would be a breaking change.

Something which might be considered but is not currently implemented in `CompilationRule` is the option to supply additional processors through a secondary constructor. This would allow for the selective testing of actual processors, this would look something like the following:

```java
@RegisterExtension
static CompilationExtension compilation = CompilationExtension.withProcessor(new CustomProcessor());
```

The primary reason this isn't in this PR is because the `(Before/After)AllCallback` is incompatible with a non-static `@RegisterExtension`, which would be very confusing if a user ran into that problem. Solving it would require either changing the extension to run a compilation for each test or separating this functionality into a new class. (See [`@RegisterExtension` Instance Fields](https://junit.org/junit5/docs/5.1.1/api/org/junit/jupiter/api/extension/RegisterExtension.html))

The only questionable part is the finalization of the compilation which currently relies on a call to `CompletableFuture.get(long,TimeUnit)` with a timeout of 1 second. I'm not entirely sure if the timeout could potentially be reached during a normal execution or if there is a better way to handle that part of the synchronization.