### PR TITLE
Moe Sync

### DIFF
--- a/src/main/java/com/google/testing/compile/Compilation.java
+++ b/src/main/java/com/google/testing/compile/Compilation.java
@@ -220,16 +220,12 @@ public final class Compilation {
 
   /** Returns a description of the why the compilation failed. */
   String describeFailureDiagnostics() {
-    ImmutableList<Diagnostic<? extends JavaFileObject>> errors = errors();
-    if (errors.isEmpty()) {
-      return "Compilation produced no errors.\n";
+    ImmutableList<Diagnostic<? extends JavaFileObject>> diagnostics = diagnostics();
+    if (diagnostics.isEmpty()) {
+      return "Compilation produced no diagnostics.\n";
     }
-    StringBuilder message = new StringBuilder("Compilation produced the following errors:\n");
-    errors.stream().forEach(error -> message.append(error).append('\n'));
-    // If we compiled with -Werror we should output the warnings too
-    if (compiler.options().contains("-Werror")) {
-      warnings().stream().forEach(warning -> message.append(warning).append('\n'));
-    }
+    StringBuilder message = new StringBuilder("Compilation produced the following diagnostics:\n");
+    diagnostics.forEach(diagnostic -> message.append(diagnostic).append('\n'));
     return message.toString();
   }
 

--- a/src/test/java/com/google/testing/compile/CompilationSubjectTest.java
+++ b/src/test/java/com/google/testing/compile/CompilationSubjectTest.java
@@ -99,7 +99,8 @@ public class CompilationSubjectTest {
           .that(compilerWithGeneratorAndError().compile(HELLO_WORLD_RESOURCE))
           .succeeded();
       AssertionError expected = expectFailure.getFailure();
-      assertThat(expected.getMessage()).contains("Compilation produced the following errors:\n");
+      assertThat(expected.getMessage()).contains(
+          "Compilation produced the following diagnostics:\n");
       assertThat(expected.getMessage()).contains(FailingGeneratingProcessor.GENERATED_CLASS_NAME);
       assertThat(expected.getMessage()).contains(FailingGeneratingProcessor.GENERATED_SOURCE);
     }
@@ -112,7 +113,8 @@ public class CompilationSubjectTest {
           .that(javac().compile(HELLO_WORLD_BROKEN_RESOURCE))
           .succeeded();
       AssertionError expected = expectFailure.getFailure();
-      assertThat(expected.getMessage()).startsWith("Compilation produced the following errors:\n");
+      assertThat(expected.getMessage()).startsWith(
+          "Compilation produced the following diagnostics:\n");
       assertThat(expected.getMessage()).contains("No files were generated.");
     }
 
@@ -130,6 +132,22 @@ public class CompilationSubjectTest {
         // newer jdks throw a runtime exception whose cause is the original exception
         assertThat(expected.getCause()).isEqualTo(e);
       }
+    }
+
+    @Test
+    public void succeeded_failureReportsWarnings() {
+      expectFailure
+          .whenTesting()
+          .about(compilations())
+          .that(compilerWithWarning().compile(HELLO_WORLD_BROKEN))
+          .succeeded();
+      AssertionError expected = expectFailure.getFailure();
+      assertThat(expected.getMessage())
+          .startsWith("Compilation produced the following diagnostics:\n");
+      assertThat(expected.getMessage()).contains("No files were generated.");
+      // "this is a message" is output by compilerWithWarning() since the source has
+      // @DiagnosticMessage
+      assertThat(expected.getMessage()).contains("warning: this is a message");
     }
 
     @Test

--- a/src/test/java/com/google/testing/compile/JavaSourcesSubjectFactoryTest.java
+++ b/src/test/java/com/google/testing/compile/JavaSourcesSubjectFactoryTest.java
@@ -337,7 +337,7 @@ public class JavaSourcesSubjectFactoryTest {
         .processedWith(new FailingGeneratingProcessor())
         .compilesWithoutError();
     AssertionError expected = expectFailure.getFailure();
-    assertThat(expected.getMessage()).contains("Compilation produced the following errors:\n");
+    assertThat(expected.getMessage()).contains("Compilation produced the following diagnostics:\n");
     assertThat(expected.getMessage()).contains(FailingGeneratingProcessor.GENERATED_CLASS_NAME);
     assertThat(expected.getMessage()).contains(FailingGeneratingProcessor.GENERATED_SOURCE);
   }
@@ -350,7 +350,7 @@ public class JavaSourcesSubjectFactoryTest {
         .that(JavaFileObjects.forResource("HelloWorld-broken.java"))
         .compilesWithoutError();
     AssertionError expected = expectFailure.getFailure();
-    assertThat(expected.getMessage()).startsWith("Compilation produced the following errors:\n");
+    assertThat(expected.getMessage()).startsWith("Compilation produced the following diagnostics:\n");
     assertThat(expected.getMessage()).contains("No files were generated.");
   }
 


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Print out warnings as well as errors in describeFailureDiagnostics.

RELNOTES=`CompilationSubject.succeeded()` now shows warnings as well as errors on failure.

339219ad8e0a0a4860b3988ecf37fbb1b34cde80