### PR TITLE
[Proposal] Use Language annotation for better IDE support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,11 @@
       <artifactId>auto-common</artifactId>
       <version>0.10</version>
     </dependency>
+    <dependency>
+      <groupId>org.jetbrains</groupId>
+      <artifactId>annotations</artifactId>
+      <version>13.0</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
     <dependency>
       <groupId>org.jetbrains</groupId>
       <artifactId>annotations</artifactId>
-      <version>13.0</version>
+      <version>17.0</version>
     </dependency>
   </dependencies>
 

--- a/src/main/java/com/google/testing/compile/JavaFileObjects.java
+++ b/src/main/java/com/google/testing/compile/JavaFileObjects.java
@@ -98,8 +98,7 @@ public final class JavaFileObjects {
     final String source;
     final long lastModified;
 
-    StringSourceJavaFileObject(String fullyQualifiedName,
-        @Language("JAVA") String source) {
+    StringSourceJavaFileObject(String fullyQualifiedName, String source) {
       super(createUri(fullyQualifiedName), SOURCE);
       // TODO(gak): check that fullyQualifiedName looks like a fully qualified class name
       this.source = source;

--- a/src/main/java/com/google/testing/compile/JavaFileObjects.java
+++ b/src/main/java/com/google/testing/compile/JavaFileObjects.java
@@ -40,6 +40,7 @@ import javax.tools.ForwardingJavaFileObject;
 import javax.tools.JavaFileObject;
 import javax.tools.JavaFileObject.Kind;
 import javax.tools.SimpleJavaFileObject;
+import org.intellij.lang.annotations.Language;
 
 /**
  * A utility class for creating {@link JavaFileObject} instances.
@@ -57,7 +58,8 @@ public final class JavaFileObjects {
    * <p>Note that this method makes no attempt to verify that the name matches the contents of the
    * source and compilation errors may result if they do not match.
    */
-  public static JavaFileObject forSourceString(String fullyQualifiedName, String source) {
+  public static JavaFileObject forSourceString(String fullyQualifiedName,
+      @Language("JAVA") String source) {
     checkNotNull(fullyQualifiedName);
     if (fullyQualifiedName.startsWith("package ")) {
       throw new IllegalArgumentException(
@@ -96,7 +98,8 @@ public final class JavaFileObjects {
     final String source;
     final long lastModified;
 
-    StringSourceJavaFileObject(String fullyQualifiedName, String source) {
+    StringSourceJavaFileObject(String fullyQualifiedName,
+        @Language("JAVA") String source) {
       super(createUri(fullyQualifiedName), SOURCE);
       // TODO(gak): check that fullyQualifiedName looks like a fully qualified class name
       this.source = source;

--- a/src/test/java/com/google/testing/compile/GeneratingProcessor.java
+++ b/src/test/java/com/google/testing/compile/GeneratingProcessor.java
@@ -29,9 +29,12 @@ import javax.annotation.processing.ProcessingEnvironment;
 import javax.annotation.processing.RoundEnvironment;
 import javax.lang.model.SourceVersion;
 import javax.lang.model.element.TypeElement;
+import org.intellij.lang.annotations.Language;
 
 final class GeneratingProcessor extends AbstractProcessor {
   static final String GENERATED_CLASS_NAME = "Blah";
+
+  @Language("JAVA")
   static final String GENERATED_SOURCE = "final class Blah {\n  String blah = \"blah\";\n}";
 
   static final String GENERATED_RESOURCE_NAME = "Foo";

--- a/src/test/java/com/google/testing/compile/JavaSourcesSubjectFactoryTest.java
+++ b/src/test/java/com/google/testing/compile/JavaSourcesSubjectFactoryTest.java
@@ -30,6 +30,7 @@ import com.google.common.truth.Truth;
 import java.util.Arrays;
 import javax.tools.Diagnostic;
 import javax.tools.JavaFileObject;
+import org.intellij.lang.annotations.Language;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -810,6 +811,8 @@ public class JavaSourcesSubjectFactoryTest {
   @Test
   public void generatesSources_failWithNoCandidates() {
     String failingExpectationName = "ThisIsNotTheRightFile";
+
+    @Language("JAVA")
     String failingExpectationSource = "abstract class ThisIsNotTheRightFile {}";
     expectFailure
         .whenTesting()


### PR DESCRIPTION
This is a proposal to use the `@Language` annotation on java sources parameters for better support in the IDE. With this, callers/consumers would get automatic syntax highlighting in intelliJ or anywhere else that understands these annotations. This is used fairly heavily in android lint tooling as well for the same effect.

![image](https://user-images.githubusercontent.com/1361086/55116151-a9ca2780-50a3-11e9-8c41-d66a34c5778d.png)

CC @ronshapiro 