### PR TITLE
Moe Sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,9 @@
 Compile Testing
 ===============
 
+[![Maven Release][maven-shield]][maven-link]
+
 A library for testing javac compilation with or without annotation processors. See the [javadoc][package-info] for usage examples.
-
-Latest Release
---------------
-
-The latest release is version `0.15`.  Include it as a [Maven](http://maven.apache.org/) dependency with the following snippet:
-
-```
-<dependency>
-  <groupId>com.google.testing.compile</groupId>
-  <artifactId>compile-testing</artifactId>
-  <version>0.15</version>
-  <scope>test</scope>
-</dependency>
-```
 
 License
 -------
@@ -35,3 +23,5 @@ License
     limitations under the License.
 
 [package-info]: https://github.com/google/compile-testing/blob/master/src/main/java/com/google/testing/compile/package-info.java
+[maven-shield]: https://img.shields.io/maven-central/v/com.google.testing.compile/compile-testing.png
+[maven-link]: https://search.maven.org/artifact/com.google.testing.compile/compile-testing

--- a/src/main/java/com/google/testing/compile/CompilationSubject.java
+++ b/src/main/java/com/google/testing/compile/CompilationSubject.java
@@ -331,9 +331,10 @@ public final class CompilationSubject extends Subject<CompilationSubject, Compil
 
   private JavaFileObjectSubject checkGeneratedFile(
       Optional<JavaFileObject> generatedFile, Location location, String format, Object... args) {
+    String name = args.length == 0 ? format : String.format(format, args);
     if (!generatedFile.isPresent()) {
       StringBuilder builder = new StringBuilder("generated the file ");
-      builder.append(args.length == 0 ? format : String.format(format, args));
+      builder.append(name);
       builder.append("; it generated:\n");
       for (JavaFileObject generated : actual().generatedFiles()) {
         if (generated.toUri().getPath().contains(location.getName())) {
@@ -343,7 +344,7 @@ public final class CompilationSubject extends Subject<CompilationSubject, Compil
       fail(builder.toString());
       return ignoreCheck().about(javaFileObjects()).that(ALREADY_FAILED);
     }
-    return check().about(javaFileObjects()).that(generatedFile.get());
+    return check("generatedFile(%s)", name).about(javaFileObjects()).that(generatedFile.get());
   }
 
   private static <T> Collector<T, ?, ImmutableList<T>> toImmutableList() {

--- a/src/main/java/com/google/testing/compile/JavaFileObjectSubject.java
+++ b/src/main/java/com/google/testing/compile/JavaFileObjectSubject.java
@@ -99,8 +99,8 @@ public final class JavaFileObjectSubject extends Subject<JavaFileObjectSubject, 
   public StringSubject contentsAsString(Charset charset) {
     try {
       return check()
-          .that(JavaFileObjects.asByteSource(actual()).asCharSource(charset).read())
-          .named("the contents of " + actualAsString());
+          .withMessage("the contents of " + actualAsString())
+          .that(JavaFileObjects.asByteSource(actual()).asCharSource(charset).read());
     } catch (IOException e) {
       throw new RuntimeException(e);
     }

--- a/src/main/java/com/google/testing/compile/JavaFileObjectSubject.java
+++ b/src/main/java/com/google/testing/compile/JavaFileObjectSubject.java
@@ -98,8 +98,7 @@ public final class JavaFileObjectSubject extends Subject<JavaFileObjectSubject, 
    */
   public StringSubject contentsAsString(Charset charset) {
     try {
-      return check()
-          .withMessage("the contents of " + actualAsString())
+      return check("contents()")
           .that(JavaFileObjects.asByteSource(actual()).asCharSource(charset).read());
     } catch (IOException e) {
       throw new RuntimeException(e);

--- a/src/main/java/com/google/testing/compile/JavaSourcesSubject.java
+++ b/src/main/java/com/google/testing/compile/JavaSourcesSubject.java
@@ -306,7 +306,7 @@ public final class JavaSourcesSubject
     @Override
     public SuccessfulCompilationClause compilesWithoutError() {
       Compilation compilation = compilation();
-      check().about(compilations()).that(compilation).succeeded();
+      check("compilation()").about(compilations()).that(compilation).succeeded();
       return new SuccessfulCompilationBuilder(compilation);
     }
 
@@ -314,7 +314,7 @@ public final class JavaSourcesSubject
     @Override
     public CleanCompilationClause compilesWithoutWarnings() {
       Compilation compilation = compilation();
-      check().about(compilations()).that(compilation).succeededWithoutWarnings();
+      check("compilation()").about(compilations()).that(compilation).succeededWithoutWarnings();
       return new CleanCompilationBuilder(compilation);
     }
 
@@ -322,7 +322,7 @@ public final class JavaSourcesSubject
     @Override
     public UnsuccessfulCompilationClause failsToCompile() {
       Compilation compilation = compilation();
-      check().about(compilations()).that(compilation).failed();
+      check("compilation()").about(compilations()).that(compilation).failed();
       return new UnsuccessfulCompilationBuilder(compilation);
     }
 
@@ -362,7 +362,7 @@ public final class JavaSourcesSubject
     @CanIgnoreReturnValue
     @Override
     public T withNoteCount(int noteCount) {
-      check().about(compilations()).that(compilation).hadNoteCount(noteCount);
+      check("compilation()").about(compilations()).that(compilation).hadNoteCount(noteCount);
       return thisObject();
     }
 
@@ -370,13 +370,16 @@ public final class JavaSourcesSubject
     @Override
     public FileClause<T> withNoteContaining(String messageFragment) {
       return new FileBuilder(
-          check().about(compilations()).that(compilation).hadNoteContaining(messageFragment));
+          check("compilation()")
+              .about(compilations())
+              .that(compilation)
+              .hadNoteContaining(messageFragment));
     }
 
     @CanIgnoreReturnValue
     @Override
     public T withWarningCount(int warningCount) {
-      check().about(compilations()).that(compilation).hadWarningCount(warningCount);
+      check("compilation()").about(compilations()).that(compilation).hadWarningCount(warningCount);
       return thisObject();
     }
 
@@ -384,19 +387,25 @@ public final class JavaSourcesSubject
     @Override
     public FileClause<T> withWarningContaining(String messageFragment) {
       return new FileBuilder(
-          check().about(compilations()).that(compilation).hadWarningContaining(messageFragment));
+          check("compilation()")
+              .about(compilations())
+              .that(compilation)
+              .hadWarningContaining(messageFragment));
     }
 
     @CanIgnoreReturnValue
     public T withErrorCount(int errorCount) {
-      check().about(compilations()).that(compilation).hadErrorCount(errorCount);
+      check("compilation()").about(compilations()).that(compilation).hadErrorCount(errorCount);
       return thisObject();
     }
 
     @CanIgnoreReturnValue
     public FileClause<T> withErrorContaining(String messageFragment) {
       return new FileBuilder(
-          check().about(compilations()).that(compilation).hadErrorContaining(messageFragment));
+          check("compilation()")
+              .about(compilations())
+              .that(compilation)
+              .hadErrorContaining(messageFragment));
     }
 
     /** Returns this object, cast to {@code T}. */
@@ -466,7 +475,9 @@ public final class JavaSourcesSubject
     @CanIgnoreReturnValue
     @Override
     public T generatesSources(JavaFileObject first, JavaFileObject... rest) {
-      check().about(javaSources()).that(compilation.generatedSourceFiles())
+      check("generatedSourceFiles()")
+          .about(javaSources())
+          .that(compilation.generatedSourceFiles())
           .parsesAs(first, rest);
       return thisObject();
     }
@@ -503,7 +514,7 @@ public final class JavaSourcesSubject
     public SuccessfulFileClause<T> generatesFileNamed(
         JavaFileManager.Location location, String packageName, String relativeName) {
       final JavaFileObjectSubject javaFileObjectSubject =
-          check()
+          check("compilation()")
               .about(compilations())
               .that(compilation)
               .generatedFile(location, packageName, relativeName);
@@ -586,7 +597,16 @@ public final class JavaSourcesSubject
 
     SingleSourceAdapter(FailureMetadata failureMetadata, JavaFileObject subject) {
       super(failureMetadata, subject);
-      this.delegate = check().about(javaSources()).that(ImmutableList.of(subject));
+      /*
+       * TODO(b/131918061): It would make more sense to eliminate SingleSourceAdapter entirely.
+       * Users can already use assertThat(JavaFileObject, JavaFileObject...) above for a single
+       * file. Anyone who needs a Subject.Factory could fall back to
+       * `about(javaSources()).that(ImmutableSet.of(source))`.
+       *
+       * We could take that on, or we could wait for JavaSourcesSubject to go away entirely in favor
+       * of CompilationSubject.
+       */
+      this.delegate = check("delegate()").about(javaSources()).that(ImmutableList.of(subject));
     }
 
     @Override

--- a/src/test/java/com/google/testing/compile/JavaFileObjectSubjectTest.java
+++ b/src/test/java/com/google/testing/compile/JavaFileObjectSubjectTest.java
@@ -16,6 +16,7 @@
 
 package com.google.testing.compile;
 
+import static com.google.common.truth.ExpectFailure.assertThat;
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.testing.compile.JavaFileObjectSubject.assertThat;
 import static com.google.testing.compile.JavaFileObjectSubject.javaFileObjects;
@@ -23,7 +24,6 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.google.common.truth.ExpectFailure;
 import java.io.IOException;
-import java.util.regex.Pattern;
 import javax.tools.JavaFileObject;
 import org.junit.Rule;
 import org.junit.Test;
@@ -96,9 +96,9 @@ public final class JavaFileObjectSubjectTest {
         .contentsAsString(UTF_8)
         .containsMatch("bad+");
     AssertionError expected = expectFailure.getFailure();
-    assertThat(expected.getMessage())
-        .containsMatch("the contents of .*" + Pattern.quote(CLASS.getName()));
-    assertThat(expected.getMessage()).contains("bad+");
+    assertThat(expected).factValue("value of").isEqualTo("javaFileObject.contents()");
+    assertThat(expected).factValue("javaFileObject was").startsWith(CLASS.getName());
+    assertThat(expected).factValue("expected to contain a match for").isEqualTo("bad+");
   }
 
   @Test

--- a/src/test/java/com/google/testing/compile/JavaSourcesSubjectFactoryTest.java
+++ b/src/test/java/com/google/testing/compile/JavaSourcesSubjectFactoryTest.java
@@ -134,9 +134,9 @@ public class JavaSourcesSubjectFactoryTest {
         .withWarningContaining("what is it?");
     AssertionError expected = expectFailure.getFailure();
     assertThat(expected.getMessage())
-        .startsWith("Expected a warning containing \"what is it?\", but only found:\n");
+        .contains("Expected a warning containing \"what is it?\", but only found:\n");
     // some versions of javac wedge the file and position in the middle
-    assertThat(expected.getMessage()).endsWith("this is a message\n");
+    assertThat(expected).hasMessageThat().contains("this is a message\n");
   }
 
   @Test
@@ -246,9 +246,9 @@ public class JavaSourcesSubjectFactoryTest {
         .withNoteContaining("what is it?");
     AssertionError expected = expectFailure.getFailure();
     assertThat(expected.getMessage())
-        .startsWith("Expected a note containing \"what is it?\", but only found:\n");
+        .contains("Expected a note containing \"what is it?\", but only found:\n");
     // some versions of javac wedge the file and position in the middle
-    assertThat(expected.getMessage()).endsWith("this is a message\n");
+    assertThat(expected).hasMessageThat().contains("this is a message\n");
   }
 
   @Test
@@ -350,8 +350,9 @@ public class JavaSourcesSubjectFactoryTest {
         .that(JavaFileObjects.forResource("HelloWorld-broken.java"))
         .compilesWithoutError();
     AssertionError expected = expectFailure.getFailure();
-    assertThat(expected.getMessage()).startsWith("Compilation produced the following"
-                                                     + " diagnostics:\n");
+    assertThat(expected)
+        .hasMessageThat()
+        .contains("Compilation produced the following" + " diagnostics:\n");
     assertThat(expected.getMessage()).contains("No files were generated.");
   }
 
@@ -421,7 +422,7 @@ public class JavaSourcesSubjectFactoryTest {
         .failsToCompile();
     AssertionError expected = expectFailure.getFailure();
     assertThat(expected.getMessage())
-        .startsWith("Compilation was expected to fail, but contained no errors");
+        .contains("Compilation was expected to fail, but contained no errors");
     assertThat(expected.getMessage()).contains("No files were generated.");
   }
 
@@ -436,9 +437,9 @@ public class JavaSourcesSubjectFactoryTest {
         .withErrorContaining("some error");
     AssertionError expected = expectFailure.getFailure();
     assertThat(expected.getMessage())
-        .startsWith("Expected an error containing \"some error\", but only found:\n");
+        .contains("Expected an error containing \"some error\", but only found:\n");
     // some versions of javac wedge the file and position in the middle
-    assertThat(expected.getMessage()).endsWith("expected error!\n");
+    assertThat(expected).hasMessageThat().contains("expected error!\n");
   }
 
   @Test
@@ -534,9 +535,9 @@ public class JavaSourcesSubjectFactoryTest {
         .withWarningContaining("what is it?");
     AssertionError expected = expectFailure.getFailure();
     assertThat(expected.getMessage())
-        .startsWith("Expected a warning containing \"what is it?\", but only found:\n");
+        .contains("Expected a warning containing \"what is it?\", but only found:\n");
     // some versions of javac wedge the file and position in the middle
-    assertThat(expected.getMessage()).endsWith("this is a message\n");
+    assertThat(expected).hasMessageThat().contains("this is a message\n");
   }
 
   @Test
@@ -627,9 +628,9 @@ public class JavaSourcesSubjectFactoryTest {
         .withNoteContaining("what is it?");
     AssertionError expected = expectFailure.getFailure();
     assertThat(expected.getMessage())
-        .startsWith("Expected a note containing \"what is it?\", but only found:\n");
+        .contains("Expected a note containing \"what is it?\", but only found:\n");
     // some versions of javac wedge the file and position in the middle
-    assertThat(expected.getMessage()).endsWith("this is a message\n");
+    assertThat(expected).hasMessageThat().contains("this is a message\n");
   }
 
   @Test


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Update docs to show latest version of Compile-Testing.

f84d205cac5f6b8c07761535e3b6431f808f06de

-------

<p> Migrate from assertThat(foo).named("foo") to assertWithMessage("foo").that(foo).

(The exact change is slightly different in some cases, like when using custom subjects or check(), but it's always a migration from named(...) to [assert]WithMessage(...).)

named(...) is being removed.

This CL may slightly modify the failure messages produced, but all the old information will still be present.

3e3acef7c526769950006614b9d3b3fd0902fee6

-------

<p> Migrate Truth Subjects from no-arg check() to the overload that accepts a description.

The overload that accepts a description generally produces better failure messages:
- The first line of the message it produces is something like: "value of: myProto.getResponse()" (where "getResponse()" is taken from the provided description)
- The last line of the message it produces is something like: "myProto was: response: query was throttled" (the full value of myProto)
- And the existing text goes in between.

Additional motivation: We are deleting the no-arg overload externally (and probably internally thereafter).

663b101ccfd770e60775da3c65e590069ade2ae5