### PR TITLE
Moe Sync

### DIFF
--- a/src/main/java/com/google/testing/compile/CompilationSubject.java
+++ b/src/main/java/com/google/testing/compile/CompilationSubject.java
@@ -72,16 +72,18 @@ public final class CompilationSubject extends Subject<CompilationSubject, Compil
     return assertAbout(compilations()).that(actual);
   }
 
+  private final Compilation actual;
+
   CompilationSubject(FailureMetadata failureMetadata, Compilation actual) {
     super(failureMetadata, actual);
+    this.actual = actual;
   }
 
   /** Asserts that the compilation succeeded. */
   public void succeeded() {
-    if (actual().status().equals(FAILURE)) {
+    if (actual.status().equals(FAILURE)) {
       failWithoutActual(
-          simpleFact(
-              actual().describeFailureDiagnostics() + actual().describeGeneratedSourceFiles()));
+          simpleFact(actual.describeFailureDiagnostics() + actual.describeGeneratedSourceFiles()));
     }
   }
 
@@ -93,11 +95,11 @@ public final class CompilationSubject extends Subject<CompilationSubject, Compil
 
   /** Asserts that the compilation failed. */
   public void failed() {
-    if (actual().status().equals(SUCCESS)) {
+    if (actual.status().equals(SUCCESS)) {
       failWithoutActual(
           simpleFact(
               "Compilation was expected to fail, but contained no errors.\n\n"
-                  + actual().describeGeneratedSourceFiles()));
+                  + actual.describeGeneratedSourceFiles()));
     }
   }
 
@@ -173,7 +175,7 @@ public final class CompilationSubject extends Subject<CompilationSubject, Compil
   private void checkDiagnosticCount(
       int expectedCount, Diagnostic.Kind kind, Diagnostic.Kind... more) {
     Iterable<Diagnostic<? extends JavaFileObject>> diagnostics =
-        actual().diagnosticsOfKind(kind, more);
+        actual.diagnosticsOfKind(kind, more);
     int actualCount = size(diagnostics);
     if (actualCount != expectedCount) {
       failWithoutActual(
@@ -282,7 +284,7 @@ public final class CompilationSubject extends Subject<CompilationSubject, Compil
       Diagnostic.Kind kind,
       Diagnostic.Kind... more) {
     ImmutableList<Diagnostic<? extends JavaFileObject>> diagnosticsOfKind =
-        actual().diagnosticsOfKind(kind, more);
+        actual.diagnosticsOfKind(kind, more);
     ImmutableList<Diagnostic<? extends JavaFileObject>> diagnosticsWithMessage =
         diagnosticsOfKind
             .stream()
@@ -311,7 +313,7 @@ public final class CompilationSubject extends Subject<CompilationSubject, Compil
   /** Asserts that compilation generated a file at {@code path}. */
   @CanIgnoreReturnValue
   public JavaFileObjectSubject generatedFile(Location location, String path) {
-    return checkGeneratedFile(actual().generatedFile(location, path), location, path);
+    return checkGeneratedFile(actual.generatedFile(location, path), location, path);
   }
 
   /** Asserts that compilation generated a source file for a type with a given qualified name. */
@@ -332,7 +334,7 @@ public final class CompilationSubject extends Subject<CompilationSubject, Compil
       ImmutableList.Builder<Fact> facts = ImmutableList.builder();
       facts.add(fact("in location", location.getName()));
       facts.add(simpleFact("it generated:"));
-      for (JavaFileObject generated : actual().generatedFiles()) {
+      for (JavaFileObject generated : actual.generatedFiles()) {
         if (generated.toUri().getPath().contains(location.getName())) {
           facts.add(simpleFact("  " + generated.toUri().getPath()));
         }

--- a/src/main/java/com/google/testing/compile/JavaFileObjectSubject.java
+++ b/src/main/java/com/google/testing/compile/JavaFileObjectSubject.java
@@ -52,13 +52,16 @@ public final class JavaFileObjectSubject extends Subject<JavaFileObjectSubject, 
     return assertAbout(FACTORY).that(actual);
   }
 
+  private final JavaFileObject actual;
+
   JavaFileObjectSubject(FailureMetadata failureMetadata, JavaFileObject actual) {
     super(failureMetadata, actual);
+    this.actual = actual;
   }
 
   @Override
   protected String actualCustomStringRepresentation() {
-    return actual().toUri().getPath();
+    return actual.toUri().getPath();
   }
 
   /**
@@ -73,7 +76,7 @@ public final class JavaFileObjectSubject extends Subject<JavaFileObjectSubject, 
 
     JavaFileObject otherFile = (JavaFileObject) other;
     try {
-      if (!asByteSource(actual()).contentEquals(asByteSource(otherFile))) {
+      if (!asByteSource(actual).contentEquals(asByteSource(otherFile))) {
         failWithActual("expected to be equal to", other);
       }
     } catch (IOException e) {
@@ -84,7 +87,7 @@ public final class JavaFileObjectSubject extends Subject<JavaFileObjectSubject, 
   /** Asserts that the actual file's contents are equal to {@code expected}. */
   public void hasContents(ByteSource expected) {
     try {
-      if (!asByteSource(actual()).contentEquals(expected)) {
+      if (!asByteSource(actual).contentEquals(expected)) {
         failWithActual("expected to have contents", expected);
       }
     } catch (IOException e) {
@@ -99,7 +102,7 @@ public final class JavaFileObjectSubject extends Subject<JavaFileObjectSubject, 
   public StringSubject contentsAsString(Charset charset) {
     try {
       return check("contents()")
-          .that(JavaFileObjects.asByteSource(actual()).asCharSource(charset).read());
+          .that(JavaFileObjects.asByteSource(actual).asCharSource(charset).read());
     } catch (IOException e) {
       throw new RuntimeException(e);
     }
@@ -166,7 +169,7 @@ public final class JavaFileObjectSubject extends Subject<JavaFileObjectSubject, 
       String failureVerb,
       String expectedTitle,
       BiFunction<ParseResult, ParseResult, TreeDifference> differencingFunction) {
-    ParseResult actualResult = Parser.parse(ImmutableList.of(actual()));
+    ParseResult actualResult = Parser.parse(ImmutableList.of(actual));
     CompilationUnitTree actualTree = getOnlyElement(actualResult.compilationUnits());
 
     ParseResult expectedResult = Parser.parse(ImmutableList.of(expected));
@@ -181,11 +184,11 @@ public final class JavaFileObjectSubject extends Subject<JavaFileObjectSubject, 
               new TreeContext(actualTree, actualResult.trees()));
       try {
         failWithoutActual(
-            fact("for file", actual().toUri().getPath()),
+            fact("for file", actual.toUri().getPath()),
             fact(failureVerb, expected.toUri().getPath()),
             fact("diff", diffReport),
             fact(expectedTitle, expected.getCharContent(false)),
-            fact("but was", actual().getCharContent(false)));
+            fact("but was", actual.getCharContent(false)));
       } catch (IOException e) {
         throw new IllegalStateException(
             "Couldn't read from JavaFileObject when it was already in memory.", e);

--- a/src/main/java/com/google/testing/compile/JavaSourcesSubject.java
+++ b/src/main/java/com/google/testing/compile/JavaSourcesSubject.java
@@ -65,12 +65,14 @@ import javax.tools.JavaFileObject;
 public final class JavaSourcesSubject
     extends Subject<JavaSourcesSubject, Iterable<? extends JavaFileObject>>
     implements CompileTester, ProcessedCompileTesterFactory {
+  private final Iterable<? extends JavaFileObject> actual;
   private final List<String> options = new ArrayList<String>(Arrays.asList("-Xlint"));
   @Nullable private ClassLoader classLoader;
   @Nullable private ImmutableList<File> classPath;
 
   JavaSourcesSubject(FailureMetadata failureMetadata, Iterable<? extends JavaFileObject> subject) {
     super(failureMetadata, subject);
+    this.actual = subject;
   }
 
   @Override
@@ -150,13 +152,13 @@ public final class JavaSourcesSubject
 
     @Override
     public void parsesAs(JavaFileObject first, JavaFileObject... rest) {
-      if (Iterables.isEmpty(actual())) {
+      if (Iterables.isEmpty(actual)) {
         failWithoutActual(
             simpleFact(
                 "Compilation generated no additional source files, though some were expected."));
         return;
       }
-      ParseResult actualResult = Parser.parse(actual());
+      ParseResult actualResult = Parser.parse(actual);
       ImmutableList<Diagnostic<? extends JavaFileObject>> errors =
           actualResult.diagnosticsByKind().get(Kind.ERROR);
       if (!errors.isEmpty()) {
@@ -334,7 +336,7 @@ public final class JavaSourcesSubject
       if (classPath != null) {
         compiler = compiler.withClasspath(classPath);
       }
-      return compiler.compile(actual());
+      return compiler.compile(actual);
     }
   }
 


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Instead of calling Subject.actual(), store the actual value in a field, and read that.

actual() is being removed.

e8f2ec731dae831d0833564c7ce9c5476efa1b0b