### PR TITLE
Check that the file exists before attempting to check file contents

### DIFF
--- a/src/main/java/com/google/testing/compile/JavaSourcesSubject.java
+++ b/src/main/java/com/google/testing/compile/JavaSourcesSubject.java
@@ -500,6 +500,7 @@ public final class JavaSourcesSubject extends Subject
       for (JavaFileObject generated : compilation.generatedFiles()) {
         try {
           if (generated.getKind().equals(expected.getKind())
+              && 0 != generated.getLastModified()
               && expectedByteSource.contentEquals(JavaFileObjects.asByteSource(generated))) {
             return true;
           }


### PR DESCRIPTION
This scenario can exist if the annotation processor attempts to
look up a file but fails to find it. The compilation.generatedFiles()
will return a JavaFileObject for non-existent file and the expression
JavaFileObjects.asByteSource(generated) will generate an IOException