### PR TITLE
Add a badge to HTML Javadocs [skip ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,9 @@ Compile Testing
 ===============
 
 [![Maven Release][maven-shield]][maven-link]
+[![Javadoc][javadoc-shield]][javadoc-link]
 
-A library for testing javac compilation with or without annotation processors. See the [javadoc][package-info] for usage examples.
+A library for testing javac compilation with or without annotation processors. See the [javadoc][javadoc-link] for usage examples.
 
 License
 -------
@@ -22,6 +23,7 @@ License
     See the License for the specific language governing permissions and
     limitations under the License.
 
-[package-info]: https://github.com/google/compile-testing/blob/master/src/main/java/com/google/testing/compile/package-info.java
 [maven-shield]: https://img.shields.io/maven-central/v/com.google.testing.compile/compile-testing.png
 [maven-link]: https://search.maven.org/artifact/com.google.testing.compile/compile-testing
+[javadoc-shield]: https://javadoc.io/badge/com.google.testing.compile/compile-testing.svg?color=blue
+[javadoc-link]: https://javadoc.io/doc/com.google.testing.compile/compile-testing


### PR DESCRIPTION
javadoc.io provides free Javadoc hosting, which is easier to read than comments in Java source files.

This change adds a badge to point to the latest version of Javadoc (also with history), and updates
the link to point to the HTML version of Javadoc instead of the Java source files as it's easier to read.