### PR TITLE
MOE Sync 2020-02-06

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,9 @@ Compile Testing
 ===============
 
 [![Maven Release][maven-shield]][maven-link]
+[![Javadoc][javadoc-shield]][javadoc-link]
 
-A library for testing javac compilation with or without annotation processors. See the [javadoc][package-info] for usage examples.
+A library for testing javac compilation with or without annotation processors. See the [javadoc][javadoc-link] for usage examples.
 
 License
 -------
@@ -22,6 +23,7 @@ License
     See the License for the specific language governing permissions and
     limitations under the License.
 
-[package-info]: https://github.com/google/compile-testing/blob/master/src/main/java/com/google/testing/compile/package-info.java
 [maven-shield]: https://img.shields.io/maven-central/v/com.google.testing.compile/compile-testing.png
 [maven-link]: https://search.maven.org/artifact/com.google.testing.compile/compile-testing
+[javadoc-shield]: https://javadoc.io/badge/com.google.testing.compile/compile-testing.svg?color=blue
+[javadoc-link]: https://javadoc.io/doc/com.google.testing.compile/compile-testing

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 Compile Testing
 ===============
 
+[![Build Status][travis-shield]][travis-link]
 [![Maven Release][maven-shield]][maven-link]
 [![Javadoc][javadoc-shield]][javadoc-link]
 
@@ -23,6 +24,8 @@ License
     See the License for the specific language governing permissions and
     limitations under the License.
 
+[travis-shield]: https://travis-ci.org/google/compile-testing.svg?branch=master
+[travis-link]: https://travis-ci.org/google/compile-testing
 [maven-shield]: https://img.shields.io/maven-central/v/com.google.testing.compile/compile-testing.png
 [maven-link]: https://search.maven.org/artifact/com.google.testing.compile/compile-testing
 [javadoc-shield]: https://javadoc.io/badge/com.google.testing.compile/compile-testing.svg?color=blue


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Add a badge to HTML Javadocs [skip ci]

javadoc.io provides free Javadoc hosting, which is easier to read than comments in Java source files.

This change adds a badge to point to the latest version of Javadoc (also with history), and updates

Fixes #186

0b43a0587e8adbdd3a75afaa2cfb40ed01dbd4fc

-------

<p> Add build status badge [skip ci]

Fixes #185

4bc1041bb11501da411a84f29396a9d291e3eec4