### PR TITLE
MOE Sync 2020-04-01

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.12</version>
+      <version>4.13</version>
     </dependency>
     <dependency>
       <groupId>com.google.truth</groupId>

--- a/src/main/java/com/google/testing/compile/CompilationSubject.java
+++ b/src/main/java/com/google/testing/compile/CompilationSubject.java
@@ -466,9 +466,12 @@ public final class CompilationSubject extends Subject {
 
     /** Lists the line at a line number (1-based). */
     String listLine(long lineNumber) {
-      return lineNumber == Diagnostic.NOPOS
-          ? "(no associated line)"
-          : String.format("%4d: %s", lineNumber, linesInFile().get((int) (lineNumber - 1)));
+      if (lineNumber == Diagnostic.NOPOS) {
+        return "(no associated line)";
+      }
+      checkArgument(lineNumber > 0 && lineNumber <= linesInFile().size(),
+          "Invalid line number %s; number of lines is only %s", lineNumber, linesInFile().size());
+      return String.format("%4d: %s", lineNumber, linesInFile().get((int) (lineNumber - 1)));
     }
   }
 


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> In onLine(n), produce a sensible exception message if n is out of range. Currently you get an ArrayIndexOutOfBoundsException.

RELNOTES=Better exception in onLine(n) when n is out of range.

d7d238ad03d83a55e7ac4c33771183b9bc9af1f4