### PR TITLE
Adds a close() method to Compilation results

### DIFF
--- a/src/main/java/com/google/testing/compile/Compiler.java
+++ b/src/main/java/com/google/testing/compile/Compiler.java
@@ -28,6 +28,7 @@ import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
+import com.google.common.io.Closeables;
 import com.google.testing.compile.Compilation.Status;
 import java.io.File;
 import java.io.IOException;
@@ -205,8 +206,12 @@ public abstract class Compiler {
             files,
             succeeded,
             diagnosticCollector.getDiagnostics(),
-            fileManager.getOutputFiles());
+            fileManager.getOutputFiles(),
+            fileManager);
     if (compilation.status().equals(Status.FAILURE) && compilation.errors().isEmpty()) {
+      try {
+        fileManager.close();
+      } catch (Throwable ignored) {}
       throw new CompilationFailureException(compilation);
     }
     return compilation;


### PR DESCRIPTION
This close method will allow file manager to be closed. Otherwise, during a normal test running lots of compilations, the java process might accumulate file descriptors. These open files are generally not a problem, but in the latest MacOS Ventura, the limit of open file descriptors is set to a low number and impossible to increase.