### PR TITLE
Encode location names in InMemoryJavaFileManager file URIs

### DIFF
--- a/src/main/java/com/google/testing/compile/InMemoryJavaFileManager.java
+++ b/src/main/java/com/google/testing/compile/InMemoryJavaFileManager.java
@@ -69,7 +69,7 @@ final class InMemoryJavaFileManager extends ForwardingStandardJavaFileManager {
   }
 
   private static URI uriForFileObject(Location location, String packageName, String relativeName) {
-    StringBuilder uri = new StringBuilder("mem:///").append(location.getName()).append('/');
+    StringBuilder uri = new StringBuilder("mem:///").append(locationName(location)).append('/');
     if (!packageName.isEmpty()) {
       uri.append(packageName.replace('.', '/')).append('/');
     }
@@ -79,7 +79,18 @@ final class InMemoryJavaFileManager extends ForwardingStandardJavaFileManager {
 
   private static URI uriForJavaFileObject(Location location, String className, Kind kind) {
     return URI.create(
-        "mem:///" + location.getName() + '/' + className.replace('.', '/') + kind.extension);
+        "mem:///" + locationName(location) + '/' + className.replace('.', '/') + kind.extension);
+  }
+
+  /**
+   * Returns the name of {@code location}, with any characters that are illegal in a URI path
+   * percent-encoded. Module locations returned by {@code
+   * StandardJavaFileManager#getLocationForModule} have names such as {@code "CLASS_OUTPUT[foo]"},
+   * and the brackets would otherwise make {@link URI#create(String)} throw an {@link
+   * IllegalArgumentException}.
+   */
+  private static String locationName(Location location) {
+    return location.getName().replace("[", "%5B").replace("]", "%5D");
   }
 
   @Override

--- a/src/main/java/com/google/testing/compile/InMemoryJavaFileManager.java
+++ b/src/main/java/com/google/testing/compile/InMemoryJavaFileManager.java
@@ -33,6 +33,7 @@ import java.io.Reader;
 import java.io.StringWriter;
 import java.io.Writer;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.nio.charset.Charset;
 import java.util.HashMap;
 import java.util.Map;
@@ -69,28 +70,34 @@ final class InMemoryJavaFileManager extends ForwardingStandardJavaFileManager {
   }
 
   private static URI uriForFileObject(Location location, String packageName, String relativeName) {
-    StringBuilder uri = new StringBuilder("mem:///").append(locationName(location)).append('/');
+    String path = "/" + location.getName() + "/";
     if (!packageName.isEmpty()) {
-      uri.append(packageName.replace('.', '/')).append('/');
+      path += packageName.replace('.', '/') + "/";
     }
-    uri.append(relativeName);
-    return URI.create(uri.toString());
+    path += relativeName;
+    return memUri(path);
   }
 
   private static URI uriForJavaFileObject(Location location, String className, Kind kind) {
-    return URI.create(
-        "mem:///" + locationName(location) + '/' + className.replace('.', '/') + kind.extension);
+    String path = "/" + location.getName() + "/" + className.replace('.', '/') + kind.extension;
+    return memUri(path);
   }
 
   /**
-   * Returns the name of {@code location}, with any characters that are illegal in a URI path
-   * percent-encoded. Module locations returned by {@code
-   * StandardJavaFileManager#getLocationForModule} have names such as {@code "CLASS_OUTPUT[foo]"},
-   * and the brackets would otherwise make {@link URI#create(String)} throw an {@link
-   * IllegalArgumentException}.
+   * Returns an in-memory {@code mem:///...} URI for the given path. The multi-argument {@link URI}
+   * constructor percent-encodes any characters that are illegal in a URI path, unlike {@link
+   * URI#create(String)}, which throws {@link IllegalArgumentException}. This matters for module
+   * locations returned by {@code StandardJavaFileManager#getLocationForModule}, whose names contain
+   * brackets (e.g. {@code "CLASS_OUTPUT[foo]"}). The empty (rather than null) authority keeps the
+   * URIs in the {@code "mem:///..."} form they had before. Since the constructor quotes illegal
+   * characters rather than rejecting them, it cannot fail for the paths built here.
    */
-  private static String locationName(Location location) {
-    return location.getName().replace("[", "%5B").replace("]", "%5D");
+  private static URI memUri(String path) {
+    try {
+      return new URI("mem", "", path, null);
+    } catch (URISyntaxException impossible) {
+      throw new AssertionError(impossible);
+    }
   }
 
   @Override

--- a/src/test/java/com/google/testing/compile/InMemoryJavaFileManagerTest.java
+++ b/src/test/java/com/google/testing/compile/InMemoryJavaFileManagerTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2026 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.testing.compile;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.nio.charset.StandardCharsets;
+import javax.tools.FileObject;
+import javax.tools.JavaCompiler;
+import javax.tools.JavaFileManager.Location;
+import javax.tools.JavaFileObject;
+import javax.tools.JavaFileObject.Kind;
+import javax.tools.StandardJavaFileManager;
+import javax.tools.ToolProvider;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link InMemoryJavaFileManager}. */
+@RunWith(JUnit4.class)
+public final class InMemoryJavaFileManagerTest {
+
+  @Test
+  public void getJavaFileForOutput_moduleLocationName() throws Exception {
+    JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+    try (StandardJavaFileManager standardFileManager =
+            compiler.getStandardFileManager(null, null, StandardCharsets.UTF_8);
+        InMemoryJavaFileManager fileManager = new InMemoryJavaFileManager(standardFileManager)) {
+      // Module locations returned by StandardJavaFileManager.getLocationForModule() have brackets
+      // in their name (e.g. "CLASS_OUTPUT[foo]"), which are illegal characters in a URI path. This
+      // used to throw IllegalArgumentException.
+      JavaFileObject output =
+          fileManager.getJavaFileForOutput(moduleLocation(), "com.example.Foo", Kind.CLASS, null);
+      assertThat(output).isNotNull();
+    }
+  }
+
+  @Test
+  public void getFileForOutput_moduleLocationName() throws Exception {
+    JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+    try (StandardJavaFileManager standardFileManager =
+            compiler.getStandardFileManager(null, null, StandardCharsets.UTF_8);
+        InMemoryJavaFileManager fileManager = new InMemoryJavaFileManager(standardFileManager)) {
+      // Module locations returned by StandardJavaFileManager.getLocationForModule() have brackets
+      // in their name (e.g. "CLASS_OUTPUT[foo]"), which are illegal characters in a URI path. This
+      // used to throw IllegalArgumentException.
+      FileObject output =
+          fileManager.getFileForOutput(moduleLocation(), "com.example", "Foo.txt", null);
+      assertThat(output).isNotNull();
+    }
+  }
+
+  private static Location moduleLocation() {
+    return new Location() {
+      @Override
+      public String getName() {
+        return "CLASS_OUTPUT[foo]";
+      }
+
+      @Override
+      public boolean isOutputLocation() {
+        return true;
+      }
+    };
+  }
+}

--- a/src/test/java/com/google/testing/compile/InMemoryJavaFileManagerTest.java
+++ b/src/test/java/com/google/testing/compile/InMemoryJavaFileManagerTest.java
@@ -24,6 +24,7 @@ import javax.tools.JavaFileManager.Location;
 import javax.tools.JavaFileObject;
 import javax.tools.JavaFileObject.Kind;
 import javax.tools.StandardJavaFileManager;
+import javax.tools.StandardLocation;
 import javax.tools.ToolProvider;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -34,17 +35,33 @@ import org.junit.runners.JUnit4;
 public final class InMemoryJavaFileManagerTest {
 
   @Test
+  public void getJavaFileForOutput_standardLocation() throws Exception {
+    JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+    try (StandardJavaFileManager standardFileManager =
+            compiler.getStandardFileManager(null, null, StandardCharsets.UTF_8);
+        InMemoryJavaFileManager fileManager = new InMemoryJavaFileManager(standardFileManager)) {
+      // Standard (non-module) location names contain no characters that need escaping, so the URI
+      // keeps its previous form.
+      JavaFileObject output =
+          fileManager.getJavaFileForOutput(
+              StandardLocation.CLASS_OUTPUT, "com.example.Foo", Kind.CLASS, null);
+      assertThat(output.toUri().getRawPath()).isEqualTo("/CLASS_OUTPUT/com/example/Foo.class");
+    }
+  }
+
+  @Test
   public void getJavaFileForOutput_moduleLocationName() throws Exception {
     JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
     try (StandardJavaFileManager standardFileManager =
             compiler.getStandardFileManager(null, null, StandardCharsets.UTF_8);
         InMemoryJavaFileManager fileManager = new InMemoryJavaFileManager(standardFileManager)) {
-      // Module locations returned by StandardJavaFileManager.getLocationForModule() have brackets
-      // in their name (e.g. "CLASS_OUTPUT[foo]"), which are illegal characters in a URI path. This
-      // used to throw IllegalArgumentException.
+      // Module locations returned by StandardJavaFileManager.getLocationForModule() have names with
+      // brackets (e.g. "CLASS_OUTPUT[foo]"), which are illegal characters in a URI path. Building
+      // the output file's URI used to throw IllegalArgumentException.
       JavaFileObject output =
           fileManager.getJavaFileForOutput(moduleLocation(), "com.example.Foo", Kind.CLASS, null);
-      assertThat(output).isNotNull();
+      assertThat(output.toUri().getRawPath())
+          .isEqualTo("/CLASS_OUTPUT%5Bfoo%5D/com/example/Foo.class");
     }
   }
 
@@ -54,12 +71,27 @@ public final class InMemoryJavaFileManagerTest {
     try (StandardJavaFileManager standardFileManager =
             compiler.getStandardFileManager(null, null, StandardCharsets.UTF_8);
         InMemoryJavaFileManager fileManager = new InMemoryJavaFileManager(standardFileManager)) {
-      // Module locations returned by StandardJavaFileManager.getLocationForModule() have brackets
-      // in their name (e.g. "CLASS_OUTPUT[foo]"), which are illegal characters in a URI path. This
-      // used to throw IllegalArgumentException.
+      // Module locations returned by StandardJavaFileManager.getLocationForModule() have names with
+      // brackets (e.g. "CLASS_OUTPUT[foo]"), which are illegal characters in a URI path. Building
+      // the output file's URI used to throw IllegalArgumentException.
       FileObject output =
           fileManager.getFileForOutput(moduleLocation(), "com.example", "Foo.txt", null);
-      assertThat(output).isNotNull();
+      assertThat(output.toUri().getRawPath())
+          .isEqualTo("/CLASS_OUTPUT%5Bfoo%5D/com/example/Foo.txt");
+    }
+  }
+
+  @Test
+  public void getJavaFileForInput_moduleLocationName() throws Exception {
+    JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+    try (StandardJavaFileManager standardFileManager =
+            compiler.getStandardFileManager(null, null, StandardCharsets.UTF_8);
+        InMemoryJavaFileManager fileManager = new InMemoryJavaFileManager(standardFileManager)) {
+      // javac's module validation calls getJavaFileForInput() on the module's CLASS_OUTPUT location
+      // (see https://github.com/google/compile-testing/issues/335); building the input URI used to
+      // throw IllegalArgumentException.
+      assertThat(fileManager.getJavaFileForInput(moduleLocation(), "com.example.Foo", Kind.CLASS))
+          .isNull();
     }
   }
 


### PR DESCRIPTION
## Problem

When a compilation involves a module, javac calls `StandardJavaFileManager.getLocationForModule(CLASS_OUTPUT, name)`, which returns a `Location` whose name is `CLASS_OUTPUT[name]` (e.g. `CLASS_OUTPUT[foo]`).

`InMemoryJavaFileManager.uriForJavaFileObject()` and `uriForFileObject()` build an in-memory URI directly from `location.getName()`:

```java
"mem:///" + location.getName() + '/' + ...
```

Since `[` and `]` are illegal characters in a URI path, `URI.create("mem:///CLASS_OUTPUT[foo]/...")` throws:

```
java.lang.IllegalArgumentException: Illegal character in path at index 19: mem:///CLASS_OUTPUT[foo]/...
```

This makes it impossible to use compile-testing when the compiler resolves a module output location. (Reported in #335.)

## Fix

Percent-encode the brackets in the location name before building the URI, via a new private `locationName(Location)` helper. Standard (non-module) location names such as `SOURCE_OUTPUT` or `CLASS_OUTPUT` contain no brackets, so they are unaffected.

## Tests

Added `InMemoryJavaFileManagerTest` with two tests (`getJavaFileForOutput` and `getFileForOutput`) that exercise a location named `CLASS_OUTPUT[foo]`. Both throw the `IllegalArgumentException` before this change and pass after it.

Fixes #335.